### PR TITLE
Enh device

### DIFF
--- a/OpenBCI_Radios.h
+++ b/OpenBCI_Radios.h
@@ -83,7 +83,6 @@ public:
     void        begin(uint8_t);
     void        begin(uint8_t, uint32_t);
     void        beginDebug(uint8_t, uint32_t);
-    // void        bufferAddStreamPacket(StreamPacketBuffer *buf);
     void        bufferAddTimeSyncSentAck(void);
     void        bufferCleanChar(char *, int);
     void        bufferCleanCompleteBuffer(Buffer *, int);
@@ -111,6 +110,7 @@ public:
     void        bufferStreamFlush(StreamPacketBuffer *);
     void        bufferStreamFlushBuffers(void);
     boolean     bufferStreamReadyForNewPacket(StreamPacketBuffer *);
+    boolean     bufferStreamReadyToSendToHost(StreamPacketBuffer *buf);
     void        bufferStreamReset(void);
     void        bufferStreamReset(StreamPacketBuffer *);
     boolean     bufferStreamSendToHost(StreamPacketBuffer *buf);
@@ -173,7 +173,6 @@ public:
     void        sendPollMessageToHost(void);
     void        sendRadioMessageToHost(byte);
     void        sendStreamPackets(void);
-    void        sendTheDevicesFirstPacketToTheHost(void);
     boolean     serialWriteTimeOut(void);
     void        setByteIdForPacketBuffer(int);
     boolean     setChannelNumber(uint32_t);

--- a/OpenBCI_Radios.h
+++ b/OpenBCI_Radios.h
@@ -103,7 +103,9 @@ public:
     boolean     bufferRadioSwitchToOtherBuffer(void);
     void        bufferResetStreamPacketBuffer(void);
     boolean     bufferSerialAddChar(char);
+    boolean     bufferSerialHasData(void);
     void        bufferSerialReset(uint8_t);
+    boolean     bufferSerialTimeout(void);
     void        bufferStreamAddChar(StreamPacketBuffer *, char);
     boolean     bufferStreamAddData(char *);
     void        bufferStreamFlush(StreamPacketBuffer *);
@@ -113,6 +115,7 @@ public:
     void        bufferStreamReset(StreamPacketBuffer *);
     boolean     bufferStreamSendToHost(StreamPacketBuffer *buf);
     void        bufferStreamStoreData(StreamPacketBuffer *, char *);
+    boolean     bufferStreamTimeout(void);
     boolean     byteIdGetIsStream(uint8_t);
     int         byteIdGetPacketNumber(uint8_t);
     byte        byteIdGetStreamPacketType(uint8_t);
@@ -130,7 +133,6 @@ public:
     uint32_t    getPollTime(void);
     boolean     hasStreamPacket(void);
     boolean     hostPacketToSend(void);
-    boolean     isAStreamPacketWaitingForLaunch(void);
     boolean     isATailByte(uint8_t);
     void        ledFeedBackForPassThru(void);
     // void        moveStreamPacketToTempBuffer(volatile char *data);
@@ -176,7 +178,6 @@ public:
     void        setByteIdForPacketBuffer(int);
     boolean     setChannelNumber(uint32_t);
     boolean     setPollTime(uint32_t);
-    boolean     thereIsDataInSerialBuffer(void);
     void        writeBufferToSerial(char *,int);
 
     //////////////////////

--- a/OpenBCI_Radios.h
+++ b/OpenBCI_Radios.h
@@ -50,23 +50,24 @@ public:
     };
     // STRUCTS
     typedef struct {
-      char  data[OPENBCI_MAX_PACKET_SIZE_BYTES];
-      int   positionRead;
-      int   positionWrite;
+      char      data[OPENBCI_MAX_PACKET_SIZE_BYTES];
+      uint8_t   positionRead;
+      uint8_t   positionWrite;
     } PacketBuffer;
 
     typedef struct {
         boolean         overflowed;
-        int             numberOfPacketsToSend;
-        int             numberOfPacketsSent;
+        uint8_t         numberOfPacketsToSend;
+        uint8_t         numberOfPacketsSent;
         PacketBuffer    packetBuffer[OPENBCI_MAX_NUMBER_OF_BUFFERS];
     } Buffer;
 
     typedef struct {
-        char        typeByte;
-        char        data[OPENBCI_MAX_PACKET_SIZE_BYTES];
-        int         bytesIn;
-        boolean     flushing;
+        uint8_t         typeByte;
+        char            data[OPENBCI_MAX_PACKET_SIZE_BYTES];
+        uint8_t         bytesIn;
+        boolean         flushing;
+        STREAM_STATE    state;
     } StreamPacketBuffer;
 
     typedef struct {
@@ -82,18 +83,13 @@ public:
     void        begin(uint8_t);
     void        begin(uint8_t, uint32_t);
     void        beginDebug(uint8_t, uint32_t);
-    boolean     byteIdGetIsStream(char);
-    int         byteIdGetPacketNumber(char);
-    byte        byteIdGetStreamPacketType(char);
     // void        bufferAddStreamPacket(StreamPacketBuffer *buf);
     void        bufferAddTimeSyncSentAck(void);
-    void        bufferCleanChar(volatile char *, int);
-    void        bufferCleanCompleteBuffer(volatile Buffer *, int);
-    void        bufferCleanCompletePacketBuffer(volatile PacketBuffer *, int);
-    void        bufferCleanPacketBuffer(volatile PacketBuffer *,int);
-    void        bufferCleanBuffer(volatile Buffer *, int);
-    void        bufferCleanSerial(int);
-    void        bufferCleanStreamPackets(int);
+    void        bufferCleanChar(char *, int);
+    void        bufferCleanCompleteBuffer(Buffer *, int);
+    void        bufferCleanCompletePacketBuffer(PacketBuffer *, int);
+    void        bufferCleanPacketBuffer(PacketBuffer *,int);
+    void        bufferCleanBuffer(Buffer *, int);
     boolean     bufferRadioAddData(BufferRadio *, char *, int, boolean);
     void        bufferRadioClean(BufferRadio *);
     boolean     bufferRadioHasData(BufferRadio *);
@@ -106,15 +102,22 @@ public:
     void        bufferRadioReset(BufferRadio *);
     boolean     bufferRadioSwitchToOtherBuffer(void);
     void        bufferResetStreamPacketBuffer(void);
+    boolean     bufferSerialAddChar(char);
+    void        bufferSerialReset(uint8_t);
+    void        bufferStreamAddChar(StreamPacketBuffer *, char);
     boolean     bufferStreamAddData(char *);
     void        bufferStreamFlush(StreamPacketBuffer *);
     void        bufferStreamFlushBuffers(void);
     boolean     bufferStreamReadyForNewPacket(StreamPacketBuffer *);
     void        bufferStreamReset(void);
     void        bufferStreamReset(StreamPacketBuffer *);
+    boolean     bufferStreamSendToHost(StreamPacketBuffer *buf);
     void        bufferStreamStoreData(StreamPacketBuffer *, char *);
-    char        byteIdMake(boolean, int, volatile char *, int);
-    byte        byteIdMakeStreamPacketType(void);
+    boolean     byteIdGetIsStream(uint8_t);
+    int         byteIdGetPacketNumber(uint8_t);
+    byte        byteIdGetStreamPacketType(uint8_t);
+    char        byteIdMake(boolean, uint8_t, char *, uint8_t);
+    byte        byteIdMakeStreamPacketType(uint8_t);
     boolean     commsFailureTimeout(void);
     void        configure(uint8_t,uint32_t);
     void        configureDevice(void);
@@ -128,7 +131,7 @@ public:
     boolean     hasStreamPacket(void);
     boolean     hostPacketToSend(void);
     boolean     isAStreamPacketWaitingForLaunch(void);
-    boolean     isATailByteChar(char);
+    boolean     isATailByte(uint8_t);
     void        ledFeedBackForPassThru(void);
     // void        moveStreamPacketToTempBuffer(volatile char *data);
     boolean     needToSetChannelNumber(void);
@@ -150,7 +153,6 @@ public:
     void        printPollTime(char);
     void        printSuccess(void);
     void        printValidatedCommsTimeout(void);
-    char        processSerialCharDevice(char);
     void        processCommsFailure(void);
     void        processCommsFailureSinglePacket(void);
     boolean     processDeviceRadioCharData(char *, int);
@@ -169,13 +171,11 @@ public:
     void        sendPollMessageToHost(void);
     void        sendRadioMessageToHost(byte);
     void        sendStreamPackets(void);
-    boolean     sendStreamPacketToTheHost(void);
     void        sendTheDevicesFirstPacketToTheHost(void);
     boolean     serialWriteTimeOut(void);
     void        setByteIdForPacketBuffer(int);
     boolean     setChannelNumber(uint32_t);
     boolean     setPollTime(uint32_t);
-    boolean     storeCharToSerialBuffer(char);
     boolean     thereIsDataInSerialBuffer(void);
     void        writeBufferToSerial(char *,int);
 
@@ -202,6 +202,7 @@ public:
     unsigned long timeOfLastMultipacketSendToHost;
 
     boolean channelNumberSaveAttempted;
+    boolean streamPacketsHaveHeads;
     volatile boolean isWaitingForNewChannelNumberConfirmation;
     volatile boolean isWaitingForNewPollTimeConfirmation;
     volatile boolean sendSerialAck;

--- a/README.md
+++ b/README.md
@@ -75,14 +75,6 @@ A buffer to read into the ring buffer
 
 Adds a `,` to the main ring buffer. Used to ack that a time sync set command was sent.
 
-### bufferCleanSerial(numberOfPacketsToClean)
-
-Function to clean (clear/reset) the bufferSerial.
-
-**_numberOfPacketsToClean_** - `int`
-
-The number of packets you want to clean, for example, on init, we would clean all packets, but on cleaning from the RFduinoGZLL_onReceive() we would only clean the number of packets actually used.
-
 ### bufferRadioClean()
 
 Used to fill the buffer with all zeros. Should be used as frequently as possible. This is very useful if you need to ensure that no bad data is sent over the serial port.
@@ -107,10 +99,6 @@ Used to determine if there is data in the radio buffer. Most likely this data ne
 
 Used to reset the flags and positions of the radio buffer.
 
-### bufferResetStreamPacketBuffer()
-
-Resets the stream packet buffer to default settings
-
 ### bufferSerialAddChar(newChar)
 
 Stores a char to the serial buffer. Used by both the Device and the Host. Protects the system from buffer overflow.
@@ -121,7 +109,83 @@ The new char to store to the serial buffer.
 
 **_Returns_** - {boolean}
 
-`true` if the new char was added to the serial buffer,
+`true` if the new char was added to the serial buffer, `false` if not.
+
+### bufferSerialHasData()
+
+If there are packets to be sent in the serial buffer.
+
+**_Returns_** - {boolean}
+
+`true` if there are packets waiting to be sent from the serial buffer, `false` if not...
+
+### bufferSerialReset(n)
+
+Function to clean (clear/reset) the bufferSerial.
+
+**_n_** - `uint8_t`
+
+The number of packets you want to clean, for example, on init, we would clean all packets, but on cleaning from the RFduinoGZLL_onReceive() we would only clean the number of packets actually used.
+
+### bufferSerialTimeout()
+
+Based off the last time the serial port was read from, Determines if enough time has passed to qualify this data as a full serial page.
+
+**_Returns_** - {boolean}
+
+`true` if enough time has passed, `false` if not.
+
+### bufferStreamAddChar(buf, newChar)
+
+Process a char from the serial port on the Device. Enters the char into the stream state machine.
+
+**_buf_** - `StreamPacketBuffer *`
+
+The stream packet buffer to add the char to.
+
+**_newChar_** - `char`
+
+A new char to process.
+
+### bufferStreamReadyToSendToHost(buf)
+
+Utility function to return `true` if the the streamPacketBuffer is in the STREAM_STATE_READY. Normally used for determining if a stream packet is ready to be sent.
+
+**_buf_** - `StreamPacketBuffer *`
+
+The stream packet buffer to send to the Host.
+
+**_Returns_** - {boolean}
+
+`true` is the `buf` is in the ready state, `false` otherwise.
+
+### bufferStreamReset()
+
+Resets the first stream packet buffer to default settings.
+
+### bufferStreamReset(buf)
+
+Resets the stream packet buffer to default settings
+
+**_buf_** - `StreamPacketBuffer *`
+
+Pointer to a stream packet buffer to reset.
+
+### bufferStreamSendToHost(buf)
+
+Sends the contents of the `buf` to the HOST, sends as stream packet with the proper byteId.
+
+**_buf_** - `StreamPacketBuffer *`
+
+Pointer to a stream packet buffer to be sent to the Host.
+
+### bufferStreamTimeout()
+
+Based off the last time the serial port was read from, Determines if enough time has passed to qualify this data as a stream packet.
+
+**_Returns_** - {boolean}
+
+`true` if enough time has passed, `false` if not.
 
 ### commsFailureTimeout()
 
@@ -278,19 +342,6 @@ The char to be read in.
 
 `true` if a packet should be sent from the serial buffer.            
 
-
-### processSerialCharDevice(newChar)
-
-Process a char from the serial port on the Device. Stores the char not only to the serial buffer but also tries enters the char into the stream state machine.
-
-**_newChar_** - {char}
-
-A new char to process
-
-**_Returns_** - {char}
-
-Passes `newChar` back out.
-
 ### resetPic32()
 
 Sends a soft reset command to the Pic 32 incase of an emergency.
@@ -315,26 +366,10 @@ The packet number sent.
 
 Sends a null byte to the host.
 
-### sendStreamPacketToTheHost()
-
-Sends the contents of the `streamPacketBuffer` to the HOST, sends as stream packet with the proper byteId.     
-
-**_Returns_** - {boolean}
-
-`true` when the packet has been added to the TX buffer.
-
 ### serialWriteTimeOut()
 
 Used to see if enough time has passed since the last serial read. Useful to if a serial transmission from the PC/Driver has concluded.   
 
 **_Returns_** - {boolean}
 
-`true` if enough time has passed.
-
-### bufferSerialHasData()
-
-If there are packets to be sent in the serial buffer.
-
-**_Returns_** - {boolean}
-
-`true` if there are packets waiting to be sent from the serial buffer, `false` if not...       
+`true` if enough time has passed.      

--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Used to reset the flags and positions of the radio buffer.
 
 Resets the stream packet buffer to default settings
 
+### bufferSerialAddChar(newChar)
+
+Stores a char to the serial buffer. Used by both the Device and the Host. Protects the system from buffer overflow.
+
+**_newChar_** - {char}
+
+The new char to store to the serial buffer.
+
+**_Returns_** - {boolean}
+
+`true` if the new char was added to the serial buffer,
+
 ### commsFailureTimeout()
 
 The first line of defense against a system that has lost it's device. The timeout is 15ms longer than the longest poll time (255ms) possible.
@@ -326,18 +338,6 @@ Used to see if enough time has passed since the last serial read. Useful to if a
 **_Returns_** - {boolean}
 
 `true` if enough time has passed.
-
-### storeCharToSerialBuffer(newChar)
-
-Stores a char to the serial buffer. Used by both the Device and the Host. Protects the system from buffer overflow.
-
-**_newChar_** - {char}
-
-The new char to store to the serial buffer.
-
-**_Returns_** - {boolean}
-
-`true` if the new char was added to the serial buffer,
 
 ### thereIsDataInSerialBuffer()
 

--- a/README.md
+++ b/README.md
@@ -171,14 +171,6 @@ Answers the question of if a packet is ready to be sent. need to check and there
 
 `true` if there is a packet ready to send on the Host
 
-### isAStreamPacketWaitingForLaunch()
-
-Checks to see if the stream packet parser is in the STREAM_STATE_READY which means that a stream packet is ready to be sent to the Host.
-
-**_Returns_** {boolean}
-
-`true` if there is a stream packet ready to send the Host
-
 ### ledFeedBackForPassThru()
 
 Used to flash the led to indicate to the user the device is in pass through mode.
@@ -339,7 +331,7 @@ Used to see if enough time has passed since the last serial read. Useful to if a
 
 `true` if enough time has passed.
 
-### thereIsDataInSerialBuffer()
+### bufferSerialHasData()
 
 If there are packets to be sent in the serial buffer.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 * Removed function `isAStreamPacketWaitingForLaunch`. Now just check if stream packet buffer is in the ready state.
 * Renamed `thereIsDataInSerialBuffer` to `bufferSerialHasData`
+* Renamed `packetsInSerialBuffer` for `bufferSerialHasData` to follow new convention.
+* Renamed `sendStreamPacketToTheHost` to `bufferStreamSendToHost` to follow new convention.
+* Renamed `storeCharToSerialBuffer` to `bufferSerialAddChar` to follow new convention.
+* Refactored `processSerialCharDevice` into `bufferSerialAddChar` and `bufferStreamAddChar`.
 
 # v2.0.0-rc.3 - Release Candidate 3
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# v2.0.0-rc.4 - Release Candidate 4
+
+### Breaking Changes
+
+* Removed function `isAStreamPacketWaitingForLaunch`. Now just check if stream packet buffer is in the ready state.
+* Renamed `thereIsDataInSerialBuffer` to `bufferSerialHasData`
+
 # v2.0.0-rc.3 - Release Candidate 3
 
 ### Enhancements

--- a/examples/RadioDevice32bit/RadioDevice32bit.ino
+++ b/examples/RadioDevice32bit/RadioDevice32bit.ino
@@ -47,12 +47,14 @@ void loop() {
         radio.bufferSerial.overflowed = false;
 
     } else {
-        if (Serial.available()) { // Is there new serial data available?
+        while (Serial.available()) { // Is there new serial data available?
             char newChar = Serial.read();
             // Mark the last serial as now;
             radio.lastTimeSerialRead = micros();
+            // Store it to serial buffer
+            radio.bufferSerialAddChar(newChar);
             // Get one char and process it
-            radio.processSerialCharDevice(newChar);
+            radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
             // Reset the poll timer to prevent contacting the host mid read
             radio.pollRefresh();
         }
@@ -61,7 +63,7 @@ void loop() {
             // Has 80uS passed since the last time we read from the serial port?
             if (micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS)) {
                 if (radio.ackCounter < RFDUINOGZLL_MAX_PACKETS_ON_TX_BUFFER) {
-                    radio.sendStreamPacketToTheHost();
+                    radio.bufferStreamSendToHost();
                 } else {
                     // packet loss incur... never seems to happen
                 }

--- a/examples/RadioDevice32bit/RadioDevice32bit.ino
+++ b/examples/RadioDevice32bit/RadioDevice32bit.ino
@@ -59,9 +59,9 @@ void loop() {
             radio.pollRefresh();
         }
 
-        if (radio.isAStreamPacketWaitingForLaunch()) { // Is there a stream packet waiting to get sent to the Host?
+        if (radio.streamPacketBuffer->state == radio.STREAM_STATE_READY) { // Is there a stream packet waiting to get sent to the Host?
             // Has 80uS passed since the last time we read from the serial port?
-            if (micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS)) {
+            if (bufferStreamTimeout()) {
                 if (radio.ackCounter < RFDUINOGZLL_MAX_PACKETS_ON_TX_BUFFER) {
                     radio.bufferStreamSendToHost();
                 } else {
@@ -71,7 +71,7 @@ void loop() {
         } else if (radio.thereIsDataInSerialBuffer()) { // Is there data from the Pic waiting to get sent to Host
             // Has 3ms passed since the last time the serial port was read. Only the
             //  first packet get's sent from here
-            if ((micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_NRML_uS)) && radio.bufferSerial.numberOfPacketsSent == 0 ) {
+            if (bufferSerialTimeout() && radio.bufferSerial.numberOfPacketsSent == 0 ) {
                 // In order to do checksumming we must only send one packet at a time
                 //  this stands as the first time we are going to send a packet!
                 if (radio.ackCounter < RFDUINOGZLL_MAX_PACKETS_ON_TX_BUFFER) {

--- a/examples/RadioHost32bit/RadioHost32bit.ino
+++ b/examples/RadioHost32bit/RadioHost32bit.ino
@@ -48,7 +48,7 @@ void loop() {
         // Save the last time serial data was read to now
         radio.lastTimeSerialRead = micros();
         // Get data and put it on the serial buffer
-        boolean success = radio.storeCharToSerialBuffer(newChar);
+        boolean success = radio.bufferSerialAddChar(newChar);
         if (!success) {
             Serial.print("Failure: Input too large!$$$");
         }
@@ -160,7 +160,7 @@ void RFduinoGZLL_onReceive(device_t device, int rssi, char *data, int len) {
         sendDataPacket = radio.hostPacketToSend();
         if (sendDataPacket == false) {
             if (radio.bufferSerial.numberOfPacketsSent > 0) {
-                radio.bufferCleanSerial(radio.bufferSerial.numberOfPacketsSent);
+                radio.bufferSerialReset(radio.bufferSerial.numberOfPacketsSent);
             }
         }
     }

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,7 +29,6 @@ flashNonVolatileMemory          KEYWORD2
 getChannelNumber                KEYWORD2
 getPollTime                     KEYWORD2
 hostPacketToSend                KEYWORD2
-isAStreamPacketWaitingForLaunch KEYWORD2
 ledFeedBackForPassThru          KEYWORD2
 packetToSend                    KEYWORD2
 packetsInSerialBuffer           KEYWORD2
@@ -48,7 +47,7 @@ sendPollMessageToHost           KEYWORD2
 sendStreamPacketToTheHost       KEYWORD2
 serialWriteTimeOut              KEYWORD2
 storeCharToSerialBuffer         KEYWORD2
-thereIsDataInSerialBuffer       KEYWORD2
+bufferSerialHasData       KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -15,14 +15,18 @@ ringBuffer      KEYWORD1
 #######################################
 begin                           KEYWORD2
 beginDebug                      KEYWORD2
-bufferAddStreamPacket           KEYWORD2
-bufferAddTimeSyncSentAck        KEYWORD2
-bufferCleanSerial               KEYWORD2
 bufferRadioClean                KEYWORD2
 bufferRadioFlushBuffers         KEYWORD2
-bufferRadioProcessSingle        KEYWORD2
 bufferRadioReset                KEYWORD2
-bufferResetStreamPacketBuffer   KEYWORD2
+bufferSerialAddChar             KEYWORD2
+bufferSerialHasData             KEYWORD2
+bufferSerialReset               KEYWORD2
+bufferSerialTimeout             KEYWORD2
+bufferStreamAddChar             KEYWORD2
+bufferStreamReadyToSendToHost   KEYWORD2
+bufferStreamReset               KEYWORD2
+bufferStreamSendToHost          KEYWORD2
+bufferStreamTimeout             KEYWORD2
 commsFailureTimeout             KEYWORD2
 didPCSendDataToHost             KEYWORD2
 flashNonVolatileMemory          KEYWORD2
@@ -31,10 +35,8 @@ getPollTime                     KEYWORD2
 hostPacketToSend                KEYWORD2
 ledFeedBackForPassThru          KEYWORD2
 packetToSend                    KEYWORD2
-packetsInSerialBuffer           KEYWORD2
 pollRefresh                     KEYWORD2
 printMessageToDriver            KEYWORD2
-processSerialCharDevice         KEYWORD2
 processCommsFailure             KEYWORD2
 processRadioCharDevice          KEYWORD2
 processRadioCharHost            KEYWORD2
@@ -44,10 +46,7 @@ resetPic32                      KEYWORD2
 sendPacketToDevice              KEYWORD2
 sendPacketToHost                KEYWORD2
 sendPollMessageToHost           KEYWORD2
-sendStreamPacketToTheHost       KEYWORD2
 serialWriteTimeOut              KEYWORD2
-storeCharToSerialBuffer         KEYWORD2
-bufferSerialHasData       KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
+++ b/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
@@ -937,13 +937,13 @@ void testBufferStreamReset() {
     radio.streamPacketBuffer->flushing = true;
     radio.streamPacketBuffer->bytesIn = 32;
     radio.streamPacketBuffer->typeByte = 2;
-    radio.curStreamState = radio.STREAM_STATE_READY;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_READY;
 
     radio.bufferStreamReset();
     test.assertBoolean(radio.streamPacketBuffer->flushing,false,"should set flushing to false",__LINE__);
     test.assertEqualInt(radio.streamPacketBuffer->bytesIn,0,"should set bytesIn to 0",__LINE__);
     test.assertEqualInt(radio.streamPacketBuffer->typeByte,0,"should set typeByte to 0",__LINE__);
-    test.assertEqualByte(radio.curStreamState, radio.STREAM_STATE_INIT, "should set stream state back to init",__LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should set stream state back to init",__LINE__);
 
     test.it("should be able to reset the second stream buffer");
     (radio.streamPacketBuffer + 1)->flushing = true;

--- a/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
+++ b/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
@@ -56,7 +56,7 @@ void testByteIdMake() {
     byteId = radio.byteIdMake(false,9,NULL,0);
     test.assertEqualChar(byteId,(char)0x48,"Can set packet number of 9 in byteId");
 
-    radio.bufferCleanSerial(12);
+    radio.bufferSerialReset(12);
 
     for (int i = 0; i < OPENBCI_MAX_DATA_BYTES_IN_PACKET; i++) {
         radio.bufferSerial.packetBuffer->data[i] = 0;

--- a/test/arduino/Radio_Device_Tests/Radio_Device_Tests.ino
+++ b/test/arduino/Radio_Device_Tests/Radio_Device_Tests.ino
@@ -2,10 +2,14 @@
 #include "OpenBCI_Radios.h"
 #include "PTW-Arduino-Assert.h"
 
+int ledPin = 2;
+
 void setup() {
     // Get's serial up and running
+    pinMode(ledPin,OUTPUT);
     Serial.begin(115200);
     test.setSerial(Serial);
+    test.failVerbosity = true;
 }
 
 void loop() {
@@ -19,11 +23,14 @@ void loop() {
 void go() {
     // Start the test
     test.begin();
+    digitalWrite(ledPin, HIGH);
 
     testProcessChar();
+    testbufferStreamAddChar();
     testProcessRadioChar();
     testByteIdMakeStreamPacketType();
 
+    digitalWrite(ledPin, LOW);
     test.end();
 }
 
@@ -32,8 +39,103 @@ void go() {
 /*********    Process Char Tests    *********/
 /********************************************/
 /********************************************/
+
+void testbufferStreamAddChar() {
+    test.describe("bufferStreamAddChar");
+
+    testbufferStreamAddChar_STREAM_STATE_INIT();
+    testbufferStreamAddChar_STREAM_STATE_TAIL();
+    testbufferStreamAddChar_STREAM_STATE_STORING();
+    testbufferStreamAddChar_STREAM_STATE_READY();
+
+}
+
+void testbufferStreamAddChar_STREAM_STATE_INIT() {
+    test.detail("STREAM_STATE_INIT");
+
+    test.it("should recognize the start byte and change state to storing");
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    char newChar = '0';
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should enter state storing", __LINE__);
+    test.assertEqualChar(radio.streamPacketBuffer->data[0],newChar,"should have stored the new char", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,1,"should have read one byte in",__LINE__);
+}
+
+void testbufferStreamAddChar_STREAM_STATE_TAIL() {
+    test.detail("STREAM_STATE_TAIL");
+
+    char newChar = 'A';
+
+    test.it("should set the typeByte and set state to ready");
+    newChar = (char)OPENBCI_STREAM_PACKET_TAIL;
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->typeByte, newChar, "should set the type byte to the stop byte", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_READY, "should be in the ready state", __LINE__);
+
+    test.it("should set state to init if byte is not stop byte or head byte");
+    newChar = (char)0x00;
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should be in the ready state", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->bytesIn, 0, "should set bytesIn back to 0", __LINE__);
+
+    test.it("should set the state to storing if the byte is a head byte");
+    newChar = (char)OPENBCI_STREAM_PACKET_HEAD;
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should enter state storing", __LINE__);
+    test.assertEqualChar(radio.streamPacketBuffer->data[0],newChar,"should have stored the new char", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,1,"should have read one byte in",__LINE__);
+
+}
+
+void testbufferStreamAddChar_STREAM_STATE_STORING() {
+    test.detail("STREAM_STATE_STORING");
+
+    char newChar = 'A';
+    uint8_t initialBytesIn = 5;
+
+    test.it("should store the new char to the buffer in position of bytesIn and increment byteIn by 1");
+    initialBytesIn = 5;
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->bytesIn = initialBytesIn;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should remain in state storing", __LINE__);
+    test.assertEqualChar(radio.streamPacketBuffer->data[initialBytesIn],newChar,"should have stored the new char to inital bytesIn position", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,initialBytesIn + 1,"should have incremented bytes in by 1",__LINE__);
+
+    test.it("should change state to tail if 32 bytes have been read in");
+    initialBytesIn = 31;
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->bytesIn = initialBytesIn;
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_TAIL, "should change state to tail", __LINE__);
+    test.assertEqualChar(radio.streamPacketBuffer->data[initialBytesIn],newChar,"should have stored the new char to inital bytesIn position", __LINE__);
+    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,initialBytesIn + 1,"should have incremented bytes in by 32",__LINE__);
+
+}
+
+void testbufferStreamAddChar_STREAM_STATE_READY() {
+    test.it("should change to init state and set bytesIn to 0");
+    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.streamPacketBuffer->state = radio.STREAM_STATE_READY;
+    radio.streamPacketBuffer->bytesIn = 32;
+    radio.bufferStreamAddChar(radio.streamPacketBuffer,(char)0x00);
+    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should reset to init state",__LINE__);
+}
+
 void testProcessChar() {
-    testIsATailByteChar();
+    testIsATailByte();
     testProcessCharSingleChar();
     testProcessCharStreamPacket();
     testProcessCharStreamPackets();
@@ -41,15 +143,15 @@ void testProcessChar() {
     testProcessCharOverflow();
 }
 
-void testIsATailByteChar() {
-    test.describe("isATailByteChar");
+void testIsATailByte() {
+    test.describe("isATailByte");
 
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xC0),true,"Stream packet type 0");
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xC1),true,"Stream packet type 1");
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xC8),true,"Stream packet type 8");
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xCA),true,"Stream packet type 10");
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xCF),true,"Stream packet type 15");
-    test.assertEqualBoolean(radio.isATailByteChar((char)0xB0),false,"Not a stream packet type");
+    test.assertBoolean(radio.isATailByte(0xC0),true,"Stream packet type 0",__LINE__);
+    test.assertBoolean(radio.isATailByte(0xC1),true,"Stream packet type 1",__LINE__);
+    test.assertBoolean(radio.isATailByte(0xC8),true,"Stream packet type 8",__LINE__);
+    test.assertBoolean(radio.isATailByte(0xCA),true,"Stream packet type 10",__LINE__);
+    test.assertBoolean(radio.isATailByte(0xCF),true,"Stream packet type 15",__LINE__);
+    test.assertBoolean(radio.isATailByte(0xB0),false,"Not a stream packet type",__LINE__);
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -59,19 +161,22 @@ void testProcessCharSingleChar() {
     test.describe("processCharForSingleChar");
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // try to add a char
     char input = 'A';
-    radio.processChar(input);
+    // Store it to serial buffer
+    radio.bufferSerialAddChar(input);
+    // Get one char and process it
+    radio.bufferStreamAddChar(radio.streamPacketBuffer,input);
 
     // Verify serial buffer
-    test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer");
-    test.assertEqualChar(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send");
-    test.assertEqualChar(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets");
+    test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer",__LINE__);
+    test.assertEqualChar(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send",__LINE__);
+    test.assertEqualChar(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets",__LINE__);
     // Verify stream packet buffer
-    test.assertEqualChar(radio.streamPacketBuffer.data[0],input,"Char stored to stream packet buffer");
+    test.assertEqualChar(radio.streamPacketBuffer->data[0],input,"Char stored to stream packet buffer",__LINE__);
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -82,8 +187,8 @@ void testProcessCharStreamPacket() {
     test.describe("processCharForStreamPacket");
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // Write a stream packet with end byte 0xA0
     writeAStreamPacketToProcessChar(0xC0);
@@ -92,14 +197,14 @@ void testProcessCharStreamPacket() {
     //  because we just processed a char, after this test is complete, we should
     //  be far passed 90uS
     boolean notEnoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
-    test.assertEqualBoolean(notEnoughTimePassed,false,"Type 0 waiting...");
+    test.assertBoolean(notEnoughTimePassed,false,"Type 0 waiting...",__LINE__);
 
     // Do we have a stream packet waiting to launch?
-    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 0 loaded");
+    test.assertBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 0 loaded",__LINE__);
 
     // This should return true this time
     boolean enoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
-    test.assertEqualBoolean(enoughTimePassed,true,"Type 0 ready");
+    test.assertBoolean(enoughTimePassed,true,"Type 0 ready",__LINE__);
 
     ///////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
@@ -107,8 +212,8 @@ void testProcessCharStreamPacket() {
     ///////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // Write a stream packet with end byte not 0xA0
     writeAStreamPacketToProcessChar(0xC5);
@@ -117,14 +222,14 @@ void testProcessCharStreamPacket() {
     //  because we just processed a char, after this test is complete, we should
     //  be far passed 90uS
     notEnoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
-    test.assertEqualBoolean(notEnoughTimePassed,false,"Type 5 waiting");
+    test.assertBoolean(notEnoughTimePassed,false,"Type 5 waiting",__LINE__);
 
     // Do we have a stream packet waiting to launch?
-    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 5 loaded");
+    test.assertBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 5 loaded",__LINE__);
 
     // This should return true this time
     enoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
-    test.assertEqualBoolean(enoughTimePassed,true,"Type 5 ready");
+    test.assertBoolean(enoughTimePassed,true,"Type 5 ready",__LINE__);
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -136,8 +241,8 @@ void testProcessCharStreamPackets() {
     test.describe("processCharForStreamPackets");
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     int numberOfTrials = 9;
     char testMessage[] = "Sent 0";
@@ -147,7 +252,7 @@ void testProcessCharStreamPackets() {
         // Write a stream packet with end byte 0xC0
         writeAStreamPacketToProcessChar(0xC0);
         // Stream packet should be waiting
-        test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true);
+        test.assertBoolean(radio.isAStreamPacketWaitingForLaunch(),true);
         // Save the current time;
         t1 = micros();
         // Wait
@@ -155,7 +260,7 @@ void testProcessCharStreamPackets() {
         // configure the test message
         testMessage[5] = (i + 1) + '0';
         // Send the stream packet
-        test.assertEqualBoolean(radio.sendStreamPacketToTheHost(),true,testMessage);
+        test.assertBoolean(radio.bufferStreamSendToHost(radio.streamPacketBuffer),true,testMessage);
     }
 }
 
@@ -164,8 +269,8 @@ void testProcessCharNotStreamPacket() {
     test.describe("processCharForNotStreamPacket");
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // Write a stream packet
     writeAStreamPacketToProcessChar(0xC0);
@@ -174,18 +279,18 @@ void testProcessCharNotStreamPacket() {
     // Save current time as the last serial read
     radio.lastTimeSerialRead = micros();
     // Quick! Write another char
-    radio.processChar(newChar);
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
 
-    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Too many packets in");
-    test.assertEqualInt(radio.streamPacketBuffer.bytesIn,0,"0 bytes in");
+    test.assertBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Too many packets in",__LINE__);
+    test.assertEqualInt(radio.streamPacketBuffer->bytesIn,0,"0 bytes in",__LINE__);
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // Write a stream packet with a bad end byte
     writeAStreamPacketToProcessChar(0xB5);
-    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Bad end byte");
+    test.assertBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Bad end byte",__LINE__);
 
 
     // Remember to clean up after yourself
@@ -197,27 +302,27 @@ void testProcessCharOverflow() {
     test.describe("testProcessCharOverflow");
 
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 
     // Write the max number of bytes in buffers
     int maxBytes = OPENBCI_MAX_NUMBER_OF_BUFFERS * OPENBCI_MAX_DATA_BYTES_IN_PACKET;
     // Write max bytes but stop 1 before
     for (int i = 0; i < maxBytes; i++) {
-        radio.processChar(0x00);
+        radio.bufferSerialAddChar(0x00);
     }
 
     // Verify that the emergency stop flag has NOT been deployed
-    test.assertEqualBoolean(radio.bufferSerial.overflowed,false,"Overflow emergency not hit");
+    test.assertBoolean(radio.bufferSerial.overflowed,false,"Overflow emergency not hit",__LINE__);
     // Verify that there are 15 buffers filled
-    test.assertEqualInt(radio.bufferSerial.numberOfPacketsToSend,OPENBCI_MAX_NUMBER_OF_BUFFERS,"15 buffers");
+    test.assertEqualByte(radio.bufferSerial.numberOfPacketsToSend,OPENBCI_MAX_NUMBER_OF_BUFFERS,"15 buffers",__LINE__);
     // Verify the write position
-    test.assertEqualInt((radio.bufferSerial.packetBuffer + OPENBCI_MAX_NUMBER_OF_BUFFERS - 1)->positionWrite,OPENBCI_MAX_PACKET_SIZE_BYTES,"32 bytes in buffer");
+    test.assertEqualByte((radio.bufferSerial.packetBuffer + OPENBCI_MAX_NUMBER_OF_BUFFERS - 1)->positionWrite,OPENBCI_MAX_PACKET_SIZE_BYTES,"32 bytes in buffer",__LINE__);
 
     // Write one more byte to overflow the buffer
-    radio.processChar(0x00);
+    radio.bufferSerialAddChar(0x00);
     // Verify that the emergency stop flag has been deployed
-    test.assertEqualBoolean(radio.bufferSerial.overflowed,true,"Overflow emergency");
+    test.assertBoolean(radio.bufferSerial.overflowed,true,"Overflow emergency",__LINE__);
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -225,8 +330,8 @@ void testProcessCharOverflow() {
 
 void testProcessChar_CleanUp() {
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
 }
 
 /********************************************/
@@ -242,57 +347,66 @@ void testProcessRadioChar() {
 void testPacketToSend() {
     test.describe("testPacketToSend");
     // Clear the buffers
-    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferResetStreamPacketBuffer();
+    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferStreamReset(radio.streamPacketBuffer);
     // Set the buffers up to think there is a packet to be sent
     //  by triggering a serial read
     char input = 'A';
     // Set last serial read to now
     radio.lastTimeSerialRead = micros();
     // Process that char!
-    radio.processChar(input);
-    // Serial.print("Pos write: "); Serial.println(radio.bufferSerial.packetBuffer->positionWrite);
-    // test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer");
-    // test.assertEqualInt(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send");
-    // test.assertEqualInt(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets");
-
+    radio.bufferSerialAddChar(input);
     // Less than 3ms has passed, veryify we can't send a packet
-    test.assertEqualBoolean(radio.packetToSend(),false,"Can't send packet yet");
-    // Serial.print("Packets sent: "); Serial.println(radio.bufferSerial.numberOfPacketsSent);
-    // Serial.print("Packets to send: "); Serial.println(radio.bufferSerial.numberOfPacketsToSend);
+    test.assertBoolean(radio.packetToSend(),false,"Can't send packet yet",__LINE__);
     // Wait for 3 ms
     delayMicroseconds(3000);
-    // Serial.print("Packets sent: "); Serial.println(radio.bufferSerial.numberOfPacketsSent);
-    // Serial.print("Packets to send: "); Serial.println(radio.bufferSerial.numberOfPacketsToSend);
     // Re ask if there is something to send
-    test.assertEqualBoolean(radio.packetToSend(),true,"Enough time passed");
+    test.assertBoolean(radio.packetToSend(),true,"Enough time passed",__LINE__);
 
 }
 
 void testByteIdMakeStreamPacketType() {
     test.describe("byteIdMakeStreamPacketType");
 
-    radio.streamPacketBuffer.typeByte = 0xC5;
-    test.assertEqualChar(radio.byteIdMakeStreamPacketType(),5,"Can get type 5");
+    test.assertEqualChar(radio.byteIdMakeStreamPacketType(0xC5),5,"Can get type 5",__LINE__);
 
     testProcessChar_CleanUp();
 }
 
 void writeAStreamPacketToProcessChar(char endByte) {
     // Quickly write a bunch of bytes into the buffers
-    radio.processChar(0x41); // make the first one a stream one so 0x41
-    radio.processChar(0x00); // Sample number what have you
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x01); // 5 bytes - channel 1
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x02); // 8 bytes - channel 2
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x03); // 11 bytes - channel 3
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x04); // 14 bytes - channel 4
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x05); // 17 bytes - channel 5
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x06); // 20 bytes - channel 6
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x07); // 23 bytes - channel 7
-    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x08); // 26 bytes - channel 8
-    radio.processChar(0x00); radio.processChar(0x01); // 28 bytes - Aux 1
-    radio.processChar(0x00); radio.processChar(0x02); // 30 bytes - Aux 2
-    radio.processChar(0x00); radio.processChar(0x03); // 32 bytes - Aux 3
-    radio.processChar(endByte); // This locks in the final stream packet
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, 0x41); // make the first one a stream one so 0x41
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, 0x00); // Sample number what have you
+
+    for (byte i = 0; i < 8; i++) {
+        bufferStreamAdd3Byte(i);
+    }
+    // 5 bytes - channel 1
+    // 8 bytes - channel 2
+    // 11 bytes - channel 3
+    // 14 bytes - channel 4
+    // 17 bytes - channel 5
+    // 20 bytes - channel 6
+    // 23 bytes - channel 7
+    // 26 bytes - channel 8
+
+    for (byte i = 0; i < 3; i++) {
+        bufferStreamAdd2Byte(i);
+    }
+    // 28 bytes - Aux 1
+    // 30 bytes - Aux 2
+    // 32 bytes - Aux 3
+
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, endByte); // This locks in the final stream packet
     radio.lastTimeSerialRead = micros();
+}
+
+void bufferStreamAdd3Byte(byte n) {
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)n);
+}
+void bufferStreamAdd2Byte(byte n) {
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
+    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)n);
 }

--- a/test/arduino/Radio_Host_Tests/Radio_Host_Tests.ino
+++ b/test/arduino/Radio_Host_Tests/Radio_Host_Tests.ino
@@ -135,7 +135,7 @@ void testProcessOutboundBufferCharDouble_OPENBCI_HOST_CMD_BAUD_FAST() {
 }
 
 void testProcessOutboundBufferCharDouble_OPENBCI_HOST_CMD_SYS_UP() {
-    radio.bufferCleanSerial(1);
+    radio.bufferSerialReset(1);
 
     test.it("should return to print the system status success message if the system is up");
     radio.systemUp = true;


### PR DESCRIPTION
### Enhancements
- Refactor of the was the device reads and processes chars. Completely auto tested.
- Complete auto test coverage over mission critical buffer functions.
- Less packet loss over same distance as compared with previous release candidates.
- Renamed a ton of functions to follow a new convention where there are three main buffer categories:
  - `Serial` which handles non streaming data coming from serial port to radio
  - `Radio` which handles non streaming data coming from radio to serial port
  - `Stream` which handles both streaming data in both directions.
### Breaking Changes
- Removed function `isAStreamPacketWaitingForLaunch`. Now just check if stream packet buffer is in the ready state.
- Renamed `thereIsDataInSerialBuffer` to `bufferSerialHasData`
- Renamed `packetsInSerialBuffer` for `bufferSerialHasData` to follow new convention.
- Renamed `sendStreamPacketToTheHost` to `bufferStreamSendToHost` to follow new convention.
- Renamed `storeCharToSerialBuffer` to `bufferSerialAddChar` to follow new convention.
- Refactored `processSerialCharDevice` into `bufferSerialAddChar` and `bufferStreamAddChar`.
- Removed ring buffer.
