### PR TITLE
Revert "Enh device"

### DIFF
--- a/OpenBCI_Radios.cpp
+++ b/OpenBCI_Radios.cpp
@@ -115,7 +115,7 @@ void OpenBCI_Radios_Class::configure(uint8_t mode, uint32_t channelNumber) {
         bufferRadioClean(bufferRadio + 1);
         currentRadioBuffer = bufferRadio;
         currentRadioBufferNum = 0;
-        bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+        bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
 
         // Diverge program execution based on Device or Host
         switch (mode) {
@@ -159,7 +159,6 @@ void OpenBCI_Radios_Class::configureDevice(void) {
 
     timeOfLastMultipacketSendToHost = millis();
     sendingMultiPacket = false;
-    streamPacketsHaveHeads = true;
 
     bufferStreamReset();
 
@@ -565,7 +564,7 @@ void OpenBCI_Radios_Class::processCommsFailure(void) {
                 processCommsFailureSinglePacket();
                 break;
             default: // numberOfPacketsToSend > 1
-                bufferSerialReset(bufferSerial.numberOfPacketsToSend);
+                bufferCleanSerial(bufferSerial.numberOfPacketsToSend);
                 printValidatedCommsTimeout();
                 break;
         }
@@ -620,7 +619,7 @@ void OpenBCI_Radios_Class::processCommsFailureSinglePacket(void) {
         printMessageToDriver(HOST_MESSAGE_COMMS_DOWN);
     }
     // Always clear the serial buffer
-    bufferSerialReset(1);
+    bufferCleanSerial(1);
 }
 
 
@@ -665,7 +664,7 @@ boolean OpenBCI_Radios_Class::processOutboundBufferForTimeSync(void) {
             // Set flag
             packetInTXRadioBuffer = true;
             // Clear the buffer // TODO: Don't clear buffer here
-            bufferSerialReset(1);
+            bufferCleanSerial(1);
             return true;
         }
     }
@@ -699,19 +698,19 @@ byte OpenBCI_Radios_Class::processOutboundBufferCharDouble(char *buffer) {
                     printMessageToDriverFlag = true;
                 }
                 // Clear the serial buffer
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_NONE;
             case OPENBCI_HOST_CMD_BAUD_DEFAULT:
                 msgToPrint = HOST_MESSAGE_BAUD_DEFAULT;
                 printMessageToDriverFlag = true;
                 // Clear the serial buffer
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_NONE;
             case OPENBCI_HOST_CMD_BAUD_FAST:
                 msgToPrint = HOST_MESSAGE_BAUD_FAST;
                 printMessageToDriverFlag = true;
                 // Clear the serial buffer
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_NONE;
             case OPENBCI_HOST_CMD_SYS_UP:
                 if (systemUp) {
@@ -722,18 +721,18 @@ byte OpenBCI_Radios_Class::processOutboundBufferCharDouble(char *buffer) {
                     printMessageToDriverFlag = true;
                 }
                 // Clear the serial buffer
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_NONE;
             case OPENBCI_HOST_CMD_POLL_TIME_GET:
                 if (systemUp) {
                     // Send a time change request to the device
                     singleCharMsg[0] = (char)ORPM_GET_POLL_TIME;
                     // Clean the serial buffer
-                    bufferSerialReset(1);
+                    bufferCleanSerial(1);
                     return ACTION_RADIO_SEND_SINGLE_CHAR;
                 } else {
                     // Clean the serial buffer
-                    bufferSerialReset(1);
+                    bufferCleanSerial(1);
                     msgToPrint = HOST_MESSAGE_COMMS_DOWN;
                     printMessageToDriverFlag = true;
                     return ACTION_RADIO_SEND_NONE;
@@ -771,12 +770,12 @@ byte OpenBCI_Radios_Class::processOutboundBufferCharTriple(char *buffer) {
                     // Send a channel change request to the device
                     singleCharMsg[0] = (char)ORPM_CHANGE_CHANNEL_HOST_REQUEST;
                     // Clear the serial buffer
-                    bufferSerialReset(1);
+                    bufferCleanSerial(1);
                     // Send a single char message
                     return ACTION_RADIO_SEND_SINGLE_CHAR;
                 } else {
                     // Clear the serial buffer
-                    bufferSerialReset(1);
+                    bufferCleanSerial(1);
                     // Send back error message to the PC/Driver
                     msgToPrint = HOST_MESSAGE_CHAN_VERIFY;
                     printMessageToDriverFlag = true;
@@ -789,7 +788,7 @@ byte OpenBCI_Radios_Class::processOutboundBufferCharTriple(char *buffer) {
                 // Send a time change request to the device
                 singleCharMsg[0] = (char)ORPM_CHANGE_POLL_TIME_HOST_REQUEST;
                 // Clear the serial buffer
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_SINGLE_CHAR;
             case OPENBCI_HOST_CMD_CHANNEL_SET_OVERIDE:
                 if (setChannelNumber((uint32_t)buffer[OPENBCI_HOST_PRIVATE_POS_PAYLOAD])) {
@@ -799,7 +798,7 @@ byte OpenBCI_Radios_Class::processOutboundBufferCharTriple(char *buffer) {
                     msgToPrint = HOST_MESSAGE_CHAN_VERIFY;
                     printMessageToDriverFlag = true;
                 }
-                bufferSerialReset(1);
+                bufferCleanSerial(1);
                 return ACTION_RADIO_SEND_NONE;
             default:
                 return ACTION_RADIO_SEND_NORMAL;
@@ -868,6 +867,16 @@ boolean OpenBCI_Radios_Class::didPicSendDeviceSerialData(void) {
 }
 
 /**
+ * @description If there are packets to be sent in the serial buffer.
+ * @return {boolean} - `true` if there are packets waiting to be sent from the
+ *  serial buffer, `false` if not...
+ * @author AJ Keller (@pushtheworldllc)
+ */
+boolean OpenBCI_Radios_Class::thereIsDataInSerialBuffer(void) {
+    return bufferSerial.numberOfPacketsSent < bufferSerial.numberOfPacketsToSend;
+}
+
+/**
  * @description Sends a null byte to the host
  * @author AJ Keller (@pushtheworldllc)
  */
@@ -882,6 +891,34 @@ void OpenBCI_Radios_Class::sendPollMessageToHost(void) {
  */
 void OpenBCI_Radios_Class::sendRadioMessageToHost(byte msg) {
     RFduinoGZLL.sendToHost((const char*)msg,1);
+}
+
+/**
+* @description Private function to take data from the serial port and send it
+*                 to the HOST
+* @author AJ Keller (@pushtheworldllc)
+*/
+void OpenBCI_Radios_Class::sendTheDevicesFirstPacketToTheHost(void) {
+    // Is there data in bufferSerial?
+    if (bufferSerial.numberOfPacketsToSend > 0 && bufferSerial.numberOfPacketsSent == 0) {
+        // Get the packet number or type, based on streaming or not
+        int packetNumber = bufferSerial.numberOfPacketsToSend - 1;
+
+        char byteId = byteIdMake(false,packetNumber,bufferSerial.packetBuffer->data + 1, bufferSerial.packetBuffer->positionWrite - 1);
+
+        // Add the byteId to the packet
+        bufferSerial.packetBuffer->data[0] = byteId;
+
+        // Send back some data
+        RFduinoGZLL.sendToHost((char *)bufferSerial.packetBuffer->data, bufferSerial.packetBuffer->positionWrite);
+
+        // We know we just sent the first packet
+        bufferSerial.numberOfPacketsSent = 1;
+
+        pollRefresh();
+
+        bufferStreamReset();
+    }
 }
 
 void OpenBCI_Radios_Class::setByteIdForPacketBuffer(int packetNumber) {
@@ -921,11 +958,104 @@ int OpenBCI_Radios_Class::sendPacketToHost(void) {
 }
 
 /**
+ * @description Checks to see if the stream packet parser is in the STREAM_STATE_READY
+ *  which means that a stream packet is ready to be sent to the Host.
+ * @returns {boolean} `true` if there is a packet waiting.
+ * @author AJ Keller (@pushtheworldllc)
+ */
+boolean OpenBCI_Radios_Class::isAStreamPacketWaitingForLaunch(void) {
+    return curStreamState == STREAM_STATE_READY;
+}
+
+/**
  * @description Test to see if a char follows the stream tail byte format
  * @author AJ Keller (@pushtheworldllc)
  */
-boolean OpenBCI_Radios_Class::isATailByte(uint8_t newChar) {
+boolean OpenBCI_Radios_Class::isATailByteChar(char newChar) {
     return (newChar >> 4) == 0xC;
+}
+
+/**
+ * @description Process a char from the serial port on the Device. Stores the char
+ *  not only to the serial buffer but also tries enters the char into the stream
+ *  state machine.
+ * @param newChar {char} - A new char to process
+ * @returns {char} - The char that was read in
+ * @author AJ Keller (@pushtheworldllc)
+ */
+char OpenBCI_Radios_Class::processSerialCharDevice(char newChar) {
+    // Always store to serial buffer
+    boolean success = storeCharToSerialBuffer(newChar);
+    // Verify we have not over flowed
+    if (!success) return newChar;
+
+    // Process the new char
+    switch (curStreamState) {
+        case STREAM_STATE_TAIL:
+            // Is the current char equal to 0xCX where X is 0-F?
+            if (isATailByteChar(newChar)) {
+                // Set the type byte
+                streamPacketBuffer->typeByte = newChar;
+                // Change the state to ready
+                curStreamState = STREAM_STATE_READY;
+            } else {
+                // Reset the state machine
+                curStreamState = STREAM_STATE_INIT;
+                // Set bytes in to 0
+                streamPacketBuffer->bytesIn = 0;
+                // Test to see if this byte is a head byte, maybe if it's not a
+                //  tail byte then that's because a byte was dropped on the way
+                //  over from the Pic.
+                if (newChar == OPENBCI_STREAM_PACKET_HEAD) {
+                    // Move the state
+                    curStreamState = STREAM_STATE_STORING;
+                    // Store to the streamPacketBuffer
+                    streamPacketBuffer->data[0] = newChar;
+                    // Set to 1
+                    streamPacketBuffer->bytesIn = 1;
+                }
+            }
+            break;
+        case STREAM_STATE_STORING:
+            // Store to the stream packet buffer
+            streamPacketBuffer->data[streamPacketBuffer->bytesIn] = newChar;
+            // Increment the number of bytes read in
+            streamPacketBuffer->bytesIn++;
+
+            if (streamPacketBuffer->bytesIn == 32) {
+                curStreamState = STREAM_STATE_TAIL;
+                // Serial.println("SST");
+            }
+
+            break;
+        // We have called the function before we were able to send the stream
+        //  packet which means this is not a stream packet, it's part of a
+        //  bigger message
+        case STREAM_STATE_READY:
+            // Got a 34th byte, go back to start
+            curStreamState = STREAM_STATE_INIT;
+            // Serial.println("SSI");
+            // Set bytes in to 0
+            streamPacketBuffer->bytesIn = 0;
+
+            break;
+        case STREAM_STATE_INIT:
+            if (newChar == OPENBCI_STREAM_PACKET_HEAD) {
+                // Move the state
+                curStreamState = STREAM_STATE_STORING;
+                // Store to the streamPacketBuffer
+                streamPacketBuffer->data[0] = newChar;
+                // Set to 1
+                streamPacketBuffer->bytesIn = 1;
+            }
+            break;
+        default:
+            // Reset the state
+            curStreamState = STREAM_STATE_INIT;
+            break;
+
+    }
+    return newChar;
 }
 
 /**
@@ -934,6 +1064,93 @@ boolean OpenBCI_Radios_Class::isATailByte(uint8_t newChar) {
  */
 void OpenBCI_Radios_Class::resetPic32(void) {
     Serial.write('v');
+}
+
+/**
+ * @description Sends the contents of the `streamPacketBuffer` to the HOST,
+ *  sends as stream packet with the proper byteId.
+ * @returns {boolean} - `true` when the packet has been added to the TX buffer
+ * @author AJ Keller (@pushtheworldllc)
+ */
+boolean OpenBCI_Radios_Class::sendStreamPacketToTheHost(void) {
+
+    byte packetType = byteIdMakeStreamPacketType();
+    // Serial.print("Packet type: "); Serial.println(packetType);
+
+    char byteId = byteIdMake(true,packetType,streamPacketBuffer->data + 1, OPENBCI_MAX_DATA_BYTES_IN_PACKET); // 31 bytes
+
+    // Add the byteId to the packet
+    streamPacketBuffer->data[0] = byteId;
+
+    // Clean the serial buffer (because these bytes got added to it too)
+    bufferCleanSerial(bufferSerial.numberOfPacketsToSend);
+    // Serial.println("#c4\n");
+
+    // Clean the stream packet buffer
+    bufferStreamReset();
+
+    // Refresh the poll timeout timer because we just polled the Host by sending
+    //  that last packet
+    pollRefresh();
+
+    // Send the packet to the host...
+    RFduinoGZLL.sendToHost((char *)streamPacketBuffer->data, OPENBCI_MAX_PACKET_SIZE_BYTES); // 32 bytes
+    return true;
+}
+
+/**
+ * @description Stores a char to the serial buffer. Used by both the Device and
+ *  the Host.
+ * @param newChar {char} - The new char to store to the serial buffer.
+ * @return {boolean} - `true` if the new char was added to the serial buffer,
+ *  `false` on serial buffer overflow.
+ * @author AJ Keller (@pushtheworldllc)
+ */
+boolean OpenBCI_Radios_Class::storeCharToSerialBuffer(char newChar) {
+    // Is the serial buffer overflowed?
+    if (bufferSerial.overflowed) {
+        // End the subroutine
+        // Serial.println("OVR");
+        return false;
+    } else {
+        // Is the current buffer's write position less than max size of 32?
+        if (currentPacketBufferSerial->positionWrite < OPENBCI_MAX_PACKET_SIZE_BYTES) {
+            // Store the char into the serial buffer at the write position
+            currentPacketBufferSerial->data[currentPacketBufferSerial->positionWrite] = newChar;
+            // Increment the write position
+            currentPacketBufferSerial->positionWrite++;
+            // Set the number of packets to 1 initally, it will only grow
+            if (bufferSerial.numberOfPacketsToSend == 0) {
+                bufferSerial.numberOfPacketsToSend = 1;
+            }
+            // end successful subroutine read
+            return true;
+
+        } else {
+            // Are we out of serial buffers?
+            if (bufferSerial.numberOfPacketsToSend == OPENBCI_MAX_NUMBER_OF_BUFFERS) {
+                // Set the overflowed flag equal to true
+                bufferSerial.overflowed = true;
+                // Serial.println("OVR");
+                // End the subroutine with a failure
+                return false;
+
+            } else {
+                // Increment the current buffer pointer to the next one
+                currentPacketBufferSerial++;
+                // Increment the number of packets to send
+                bufferSerial.numberOfPacketsToSend++;
+                // Serial.print("#p2s1: "); Serial.println(bufferSerial.numberOfPacketsToSend);
+
+                // Store the char into the serial buffer at the write position
+                currentPacketBufferSerial->data[currentPacketBufferSerial->positionWrite] = newChar;
+                // Increment the write position
+                currentPacketBufferSerial->positionWrite++;
+                // End the subroutine with success
+                return true;
+            }
+        }
+    }
 }
 
 /********************************************/
@@ -979,7 +1196,7 @@ void OpenBCI_Radios_Class::writeBufferToSerial(char *buffer, int length) {
 * @description Private function to clear the given buffer of length
 * @author AJ Keller (@pushtheworldllc)
 */
-void OpenBCI_Radios_Class::bufferCleanChar(char *buffer, int bufferLength) {
+void OpenBCI_Radios_Class::bufferCleanChar(volatile char *buffer, int bufferLength) {
     for (int i = 0; i < bufferLength; i++) {
         buffer[i] = 0;
     }
@@ -989,7 +1206,7 @@ void OpenBCI_Radios_Class::bufferCleanChar(char *buffer, int bufferLength) {
 * @description Private function to clean a PacketBuffer.
 * @author AJ Keller (@pushtheworldllc)
 */
-void OpenBCI_Radios_Class::bufferCleanPacketBuffer(PacketBuffer *packetBuffer, int numberOfPackets) {
+void OpenBCI_Radios_Class::bufferCleanPacketBuffer(volatile PacketBuffer *packetBuffer, int numberOfPackets) {
     for(int i = 0; i < numberOfPackets; i++) {
         packetBuffer[i].positionRead = 0;
         packetBuffer[i].positionWrite = 1;
@@ -1000,7 +1217,7 @@ void OpenBCI_Radios_Class::bufferCleanPacketBuffer(PacketBuffer *packetBuffer, i
 * @description Private function to clean a PacketBuffer.
 * @author AJ Keller (@pushtheworldllc)
 */
-void OpenBCI_Radios_Class::bufferCleanCompletePacketBuffer(PacketBuffer *packetBuffer, int numberOfPackets) {
+void OpenBCI_Radios_Class::bufferCleanCompletePacketBuffer(volatile PacketBuffer *packetBuffer, int numberOfPackets) {
     for(int i = 0; i < numberOfPackets; i++) {
         packetBuffer[i].positionRead = 0;
         packetBuffer[i].positionWrite = 0;
@@ -1011,7 +1228,7 @@ void OpenBCI_Radios_Class::bufferCleanCompletePacketBuffer(PacketBuffer *packetB
 * @description Private function to clean (clear/reset) a Buffer.
 * @author AJ Keller (@pushtheworldllc)
 */
-void OpenBCI_Radios_Class::bufferCleanBuffer(Buffer *buffer, int numberOfPacketsToClean) {
+void OpenBCI_Radios_Class::bufferCleanBuffer(volatile Buffer *buffer, int numberOfPacketsToClean) {
     bufferCleanPacketBuffer(buffer->packetBuffer,numberOfPacketsToClean);
     buffer->numberOfPacketsToSend = 0;
     buffer->numberOfPacketsSent = 0;
@@ -1022,13 +1239,27 @@ void OpenBCI_Radios_Class::bufferCleanBuffer(Buffer *buffer, int numberOfPackets
 * @description Private function to clean (clear/reset) a Buffer.
 * @author AJ Keller (@pushtheworldllc)
 */
-void OpenBCI_Radios_Class::bufferCleanCompleteBuffer(Buffer *buffer, int numberOfPacketsToClean) {
+void OpenBCI_Radios_Class::bufferCleanCompleteBuffer(volatile Buffer *buffer, int numberOfPacketsToClean) {
     bufferCleanCompletePacketBuffer(buffer->packetBuffer,numberOfPacketsToClean);
     buffer->numberOfPacketsToSend = 0;
     buffer->numberOfPacketsSent = 0;
     // Serial.print("#p2s5: "); Serial.println(buffer->numberOfPacketsToSend);
 
     buffer->overflowed = false;
+}
+
+/**
+ * @description Function to clean (clear/reset) the bufferSerial.
+ * @param - `numberOfPacketsToClean` - {int} - The number of packets you want to
+ *      clean, for example, on init, we would clean all packets, but on cleaning
+ *      from the RFduinoGZLL_onReceive() we would only clean the number of
+ *      packets actually used.
+ * @author AJ Keller (@pushtheworldllc)
+ */
+void OpenBCI_Radios_Class::bufferCleanSerial(int numberOfPacketsToClean) {
+    bufferCleanBuffer(&bufferSerial, numberOfPacketsToClean);
+    currentPacketBufferSerial = bufferSerial.packetBuffer;
+    // previousPacketNumber = 0;
 }
 
 /**
@@ -1223,6 +1454,8 @@ byte OpenBCI_Radios_Class::bufferRadioProcessPacket(char *data, int len) {
  */
 void OpenBCI_Radios_Class::bufferRadioProcessSingle(BufferRadio *buf) {
     if (bufferRadioHasData(buf) && buf->gotAllPackets) {
+        // TODO: Should we check to make sure we are not already flushing?
+
         // Flush radio buffer to the driver
         bufferRadioFlush(buf);
         // Reset the radio buffer flags
@@ -1275,169 +1508,6 @@ boolean OpenBCI_Radios_Class::bufferRadioSwitchToOtherBuffer(void) {
     return false;
 }
 
-/**
- * @description Stores a char to the serial buffer. Used by both the Device and
- *  the Host.
- * @param newChar {char} - The new char to store to the serial buffer.
- * @return {boolean} - `true` if the new char was added to the serial buffer,
- *  `false` on serial buffer overflow.
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferSerialAddChar(char newChar) {
-    // Is the serial buffer overflowed?
-    if (bufferSerial.overflowed) {
-        // End the subroutine
-        // Serial.println("OVR");
-        return false;
-    } else {
-        // Is the current buffer's write position less than max size of 32?
-        if (currentPacketBufferSerial->positionWrite < OPENBCI_MAX_PACKET_SIZE_BYTES) {
-            // Store the char into the serial buffer at the write position
-            currentPacketBufferSerial->data[currentPacketBufferSerial->positionWrite] = newChar;
-            // Increment the write position
-            currentPacketBufferSerial->positionWrite++;
-            // Set the number of packets to 1 initally, it will only grow
-            if (bufferSerial.numberOfPacketsToSend == 0) {
-                bufferSerial.numberOfPacketsToSend = 1;
-            }
-            // end successful subroutine read
-            return true;
-
-        } else {
-            // Are we out of serial buffers?
-            if (bufferSerial.numberOfPacketsToSend == OPENBCI_MAX_NUMBER_OF_BUFFERS) {
-                // Set the overflowed flag equal to true
-                bufferSerial.overflowed = true;
-                // Serial.println("OVR");
-                // End the subroutine with a failure
-                return false;
-
-            } else {
-                // Increment the current buffer pointer to the next one
-                currentPacketBufferSerial++;
-                // Increment the number of packets to send
-                bufferSerial.numberOfPacketsToSend++;
-                // Serial.print("#p2s1: "); Serial.println(bufferSerial.numberOfPacketsToSend);
-
-                // Store the char into the serial buffer at the write position
-                currentPacketBufferSerial->data[currentPacketBufferSerial->positionWrite] = newChar;
-                // Increment the write position
-                currentPacketBufferSerial->positionWrite++;
-                // End the subroutine with success
-                return true;
-            }
-        }
-    }
-}
-
-/**
- * @description If there are packets to be sent in the serial buffer.
- * @return {boolean} - `true` if there are packets waiting to be sent from the
- *  serial buffer, `false` if not...
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferSerialHasData(void) {
-    return bufferSerial.numberOfPacketsSent < bufferSerial.numberOfPacketsToSend;
-}
-
-/**
- * @description Function to clean (clear/reset) the bufferSerial.
- * @param - `n` - {uint8_t} - The number of packets you want to
- *      clean, for example, on init, we would clean all packets, but on cleaning
- *      from the RFduinoGZLL_onReceive() we would only clean the number of
- *      packets actually used.
- * @author AJ Keller (@pushtheworldllc)
- */
-void OpenBCI_Radios_Class::bufferSerialReset(uint8_t n) {
-    bufferCleanBuffer(&bufferSerial, n);
-    currentPacketBufferSerial = bufferSerial.packetBuffer;
-    // previousPacketNumber = 0;
-}
-
-/**
- * @description Based off the last time the serial port was read from, Determines
- *  if enough time has passed to qualify this data as a full serial page.
- * @returns {boolean} - `true` if enough time has passed, `false` if not.
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferSerialTimeout(void) {
-    return micros() > (lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_NRML_uS);
-}
-
-/**
- * @description Process a char from the serial port on the Device. Enters the char
- *  into the stream state machine.
- * @param `buf` {StreamPacketBuffer *} - The stream packet buffer to add the char to.
- * @param `newChar` {char} - A new char to process
- * @author AJ Keller (@pushtheworldllc)
- */
-void OpenBCI_Radios_Class::bufferStreamAddChar(StreamPacketBuffer *buf, char newChar) {
-    // Process the new char
-    switch (buf->state) {
-        case STREAM_STATE_TAIL:
-            // Is the current char equal to 0xCX where X is 0-F?
-            if (isATailByte(newChar)) {
-                // Set the type byte
-                buf->typeByte = newChar;
-                // Change the state to ready
-                buf->state = STREAM_STATE_READY;
-            } else {
-                // Reset the state machine
-                buf->state = STREAM_STATE_INIT;
-                // Set bytes in to 0
-                buf->bytesIn = 0;
-                // Test to see if this byte is a head byte, maybe if it's not a
-                //  tail byte then that's because a byte was dropped on the way
-                //  over from the Pic.
-                if (newChar == OPENBCI_STREAM_PACKET_HEAD) {
-                    // Move the state
-                    buf->state = STREAM_STATE_STORING;
-                    // Store to the streamPacketBuffer
-                    buf->data[0] = newChar;
-                    // Set to 1
-                    buf->bytesIn = 1;
-                }
-            }
-            break;
-        case STREAM_STATE_STORING:
-            // Store to the stream packet buffer
-            buf->data[buf->bytesIn] = newChar;
-            // Increment the number of bytes read in
-            buf->bytesIn++;
-
-            if (buf->bytesIn == OPENBCI_MAX_PACKET_SIZE_BYTES) {
-                buf->state = STREAM_STATE_TAIL;
-            }
-
-            break;
-        // We have called the function before we were able to send the stream
-        //  packet which means this is not a stream packet, it's part of a
-        //  bigger message
-        case STREAM_STATE_READY:
-            // Got a 34th byte, go back to start
-            buf->state = STREAM_STATE_INIT;
-            // Set bytes in to 0
-            buf->bytesIn = 0;
-
-            break;
-        case STREAM_STATE_INIT:
-            if (newChar == OPENBCI_STREAM_PACKET_HEAD) {
-                // Move the state
-                buf->state = STREAM_STATE_STORING;
-                // Store to the streamPacketBuffer
-                buf->data[0] = newChar;
-                // Set to 1
-                buf->bytesIn = 1;
-            }
-            break;
-        default:
-            // // Reset the state
-            buf->state = STREAM_STATE_INIT;
-            break;
-
-    }
-}
-
 boolean OpenBCI_Radios_Class::bufferStreamAddData(char *data) {
     if (bufferStreamReadyForNewPacket(streamPacketBuffer)) {
         bufferStreamStoreData(streamPacketBuffer, data);
@@ -1479,18 +1549,6 @@ boolean OpenBCI_Radios_Class::bufferStreamReadyForNewPacket(StreamPacketBuffer *
 }
 
 /**
- * @description Utility function to return `true` if the the streamPacketBuffer
- *   is in the STREAM_STATE_READY. Normally used for determining if a stream
- *   packet is ready to be sent.
- * @param `buf` {StreamPacketBuffer *} - The stream packet buffer to send to the Host.
- * @returns {boolean} - `true` is the `buf` is in the ready state, `false` otherwise.
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferStreamReadyToSendToHost(StreamPacketBuffer *buf) {
-    return radio.streamPacketBuffer->state == radio.STREAM_STATE_READY;
-}
-
-/**
  * @description Resets the stream packet buffer to default settings
  * @author AJ Keller (@pushtheworldllc)
  */
@@ -1498,51 +1556,18 @@ void OpenBCI_Radios_Class::bufferStreamReset(void) {
     streamPacketBuffer->flushing = false;
     streamPacketBuffer->bytesIn = 0;
     streamPacketBuffer->typeByte = 0;
-    streamPacketBuffer->state = STREAM_STATE_INIT;
+    curStreamState = STREAM_STATE_INIT;
 }
 
 /**
  * @description Resets the stream packet buffer to default settings
- * @param `buf` {StreamPacketBuffer *} - Pointer to a stream packet buffer to reset
+ * @param `buf` {StreamPacketBuffer *} Pointer to a stream packet buffer to reset
  * @author AJ Keller (@pushtheworldllc)
  */
 void OpenBCI_Radios_Class::bufferStreamReset(StreamPacketBuffer *buf) {
     buf->flushing = false;
     buf->bytesIn = 0;
     buf->typeByte = 0;
-    buf->state = STREAM_STATE_INIT;
-}
-
-/**
- * @description Sends the contents of the `streamPacketBuffer` to the HOST,
- *  sends as stream packet with the proper byteId.
- * @returns {boolean} - `true` when the packet has been added to the TX buffer
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferStreamSendToHost(StreamPacketBuffer *buf) {
-
-    byte packetType = byteIdMakeStreamPacketType(buf->typeByte);
-    // Serial.print("Packet type: "); Serial.println(packetType);
-
-    char byteId = byteIdMake(true,packetType,buf->data + 1, OPENBCI_MAX_DATA_BYTES_IN_PACKET); // 31 bytes
-
-    // Add the byteId to the packet
-    buf->data[0] = byteId;
-
-    // Clean the serial buffer (because these bytes got added to it too)
-    bufferSerialReset(bufferSerial.numberOfPacketsToSend);
-
-    // Send the packet to the host...
-    RFduinoGZLL.sendToHost((char *)buf->data, OPENBCI_MAX_PACKET_SIZE_BYTES); // 32 bytes
-
-    // Refresh the poll timeout timer because we just polled the Host by sending
-    //  that last packet
-    pollRefresh();
-
-    // Clean the stream packet buffer
-    bufferStreamReset(buf);
-
-    return true;
 }
 
 void OpenBCI_Radios_Class::bufferStreamStoreData(StreamPacketBuffer *buf, char *data) {
@@ -1554,19 +1579,9 @@ void OpenBCI_Radios_Class::bufferStreamStoreData(StreamPacketBuffer *buf, char *
 }
 
 /**
- * @description Based off the last time the serial port was read from, determines
- *  if enough time has passed to qualify this data as a stream packet.
- * @returns {boolean} - `true` if enough time has passed, `false` if not.
- * @author AJ Keller (@pushtheworldllc)
- */
-boolean OpenBCI_Radios_Class::bufferStreamTimeout(void) {
-    return micros() > (lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
-}
-
-/**
 * @description Creates a byteId for sending data over the RFduinoGZLL
 * @param isStreamPacket [boolean] Set true if this is a streaming packet
-* @param packetNumber {uint8_t} What number packet are you trying to send?
+* @param packetNumber [int] What number packet are you trying to send?
 * @param data [char *] The data you want to send. NOTE: Do not send the address
 *           of the entire buffer, send this method address of buffer + 1
 * @param length [int] The length of the data buffer
@@ -1576,7 +1591,7 @@ boolean OpenBCI_Radios_Class::bufferStreamTimeout(void) {
 *           Bits[2:0] - The check sum
 * @author AJ Keller (@pushtheworldllc)
 */
-char OpenBCI_Radios_Class::byteIdMake(boolean isStreamPacket, uint8_t packetNumber, char *data, uint8_t length) {
+char OpenBCI_Radios_Class::byteIdMake(boolean isStreamPacket, int packetNumber, volatile char *data, int length) {
     // Set output initially equal to 0
     char output = 0x00;
 
@@ -1596,7 +1611,7 @@ char OpenBCI_Radios_Class::byteIdMake(boolean isStreamPacket, uint8_t packetNumb
 * @returns [int] the check sum
 * @author AJ Keller (@pushtheworldllc)
 */
-boolean OpenBCI_Radios_Class::byteIdGetIsStream(uint8_t byteId) {
+boolean OpenBCI_Radios_Class::byteIdGetIsStream(char byteId) {
     return byteId > 0x7F;
 }
 
@@ -1606,7 +1621,7 @@ boolean OpenBCI_Radios_Class::byteIdGetIsStream(uint8_t byteId) {
 * @returns [int] the packetNumber
 * @author AJ Keller (@pushtheworldllc)
 */
-int OpenBCI_Radios_Class::byteIdGetPacketNumber(uint8_t byteId) {
+int OpenBCI_Radios_Class::byteIdGetPacketNumber(char byteId) {
     return (int)((byteId & 0x78) >> 3);
 }
 
@@ -1616,7 +1631,7 @@ int OpenBCI_Radios_Class::byteIdGetPacketNumber(uint8_t byteId) {
 * @returns [byte] the packet type
 * @author AJ Keller (@pushtheworldllc)
 */
-byte OpenBCI_Radios_Class::byteIdGetStreamPacketType(uint8_t byteId) {
+byte OpenBCI_Radios_Class::byteIdGetStreamPacketType(char byteId) {
     return (byte)((byteId & 0x78) >> 3);
 }
 
@@ -1625,8 +1640,8 @@ byte OpenBCI_Radios_Class::byteIdGetStreamPacketType(uint8_t byteId) {
 * @returns [byte] the packet type
 * @author AJ Keller (@pushtheworldllc)
 */
-byte OpenBCI_Radios_Class::byteIdMakeStreamPacketType(uint8_t typeByte) {
-    return typeByte & 0x0F;
+byte OpenBCI_Radios_Class::byteIdMakeStreamPacketType(void) {
+    return (byte)(streamPacketBuffer->typeByte & 0x0F);
 }
 
 /**
@@ -1828,21 +1843,21 @@ boolean OpenBCI_Radios_Class::processRadioCharDevice(char newChar) {
 
             case ORPM_GET_POLL_TIME:
                 // If there are no packets to send
-                bufferSerialAddChar('S');
-                bufferSerialAddChar('u');
-                bufferSerialAddChar('c');
-                bufferSerialAddChar('c');
-                bufferSerialAddChar('e');
-                bufferSerialAddChar('s');
-                bufferSerialAddChar('s');
-                bufferSerialAddChar(':');
-                bufferSerialAddChar(' ');
-                bufferSerialAddChar('0');
-                bufferSerialAddChar('x');
-                bufferSerialAddChar((char)getPollTime());
-                bufferSerialAddChar('$');
-                bufferSerialAddChar('$');
-                bufferSerialAddChar('$');
+                storeCharToSerialBuffer('S');
+                storeCharToSerialBuffer('u');
+                storeCharToSerialBuffer('c');
+                storeCharToSerialBuffer('c');
+                storeCharToSerialBuffer('e');
+                storeCharToSerialBuffer('s');
+                storeCharToSerialBuffer('s');
+                storeCharToSerialBuffer(':');
+                storeCharToSerialBuffer(' ');
+                storeCharToSerialBuffer('0');
+                storeCharToSerialBuffer('x');
+                storeCharToSerialBuffer((char)getPollTime());
+                storeCharToSerialBuffer('$');
+                storeCharToSerialBuffer('$');
+                storeCharToSerialBuffer('$');
                 pollRefresh();
                 return true;
 
@@ -1932,7 +1947,7 @@ boolean OpenBCI_Radios_Class::processDeviceRadioCharData(char *data, int len) {
                 return true;
             } else if (bufferSerial.numberOfPacketsSent == bufferSerial.numberOfPacketsToSend && bufferSerial.numberOfPacketsToSend != 0) {
                 // Clear buffer
-                bufferSerialReset(bufferSerial.numberOfPacketsSent);
+                bufferCleanSerial(bufferSerial.numberOfPacketsSent);
                 return false;
             } else {
                 pollHost();
@@ -1986,7 +2001,7 @@ boolean OpenBCI_Radios_Class::processHostRadioCharData(device_t device, char *da
     } else if (bufferSerial.numberOfPacketsSent == bufferSerial.numberOfPacketsToSend && bufferSerial.numberOfPacketsToSend != 0) {
         // Serial.println("Cleaning Hosts's bufferSerial");
         // Clear buffer
-        bufferSerialReset(bufferSerial.numberOfPacketsSent);
+        bufferCleanSerial(bufferSerial.numberOfPacketsSent);
         return false;
     }
 

--- a/OpenBCI_Radios.h
+++ b/OpenBCI_Radios.h
@@ -50,24 +50,23 @@ public:
     };
     // STRUCTS
     typedef struct {
-      char      data[OPENBCI_MAX_PACKET_SIZE_BYTES];
-      uint8_t   positionRead;
-      uint8_t   positionWrite;
+      char  data[OPENBCI_MAX_PACKET_SIZE_BYTES];
+      int   positionRead;
+      int   positionWrite;
     } PacketBuffer;
 
     typedef struct {
         boolean         overflowed;
-        uint8_t         numberOfPacketsToSend;
-        uint8_t         numberOfPacketsSent;
+        int             numberOfPacketsToSend;
+        int             numberOfPacketsSent;
         PacketBuffer    packetBuffer[OPENBCI_MAX_NUMBER_OF_BUFFERS];
     } Buffer;
 
     typedef struct {
-        uint8_t         typeByte;
-        char            data[OPENBCI_MAX_PACKET_SIZE_BYTES];
-        uint8_t         bytesIn;
-        boolean         flushing;
-        STREAM_STATE    state;
+        char        typeByte;
+        char        data[OPENBCI_MAX_PACKET_SIZE_BYTES];
+        int         bytesIn;
+        boolean     flushing;
     } StreamPacketBuffer;
 
     typedef struct {
@@ -83,12 +82,18 @@ public:
     void        begin(uint8_t);
     void        begin(uint8_t, uint32_t);
     void        beginDebug(uint8_t, uint32_t);
+    boolean     byteIdGetIsStream(char);
+    int         byteIdGetPacketNumber(char);
+    byte        byteIdGetStreamPacketType(char);
+    // void        bufferAddStreamPacket(StreamPacketBuffer *buf);
     void        bufferAddTimeSyncSentAck(void);
-    void        bufferCleanChar(char *, int);
-    void        bufferCleanCompleteBuffer(Buffer *, int);
-    void        bufferCleanCompletePacketBuffer(PacketBuffer *, int);
-    void        bufferCleanPacketBuffer(PacketBuffer *,int);
-    void        bufferCleanBuffer(Buffer *, int);
+    void        bufferCleanChar(volatile char *, int);
+    void        bufferCleanCompleteBuffer(volatile Buffer *, int);
+    void        bufferCleanCompletePacketBuffer(volatile PacketBuffer *, int);
+    void        bufferCleanPacketBuffer(volatile PacketBuffer *,int);
+    void        bufferCleanBuffer(volatile Buffer *, int);
+    void        bufferCleanSerial(int);
+    void        bufferCleanStreamPackets(int);
     boolean     bufferRadioAddData(BufferRadio *, char *, int, boolean);
     void        bufferRadioClean(BufferRadio *);
     boolean     bufferRadioHasData(BufferRadio *);
@@ -101,26 +106,15 @@ public:
     void        bufferRadioReset(BufferRadio *);
     boolean     bufferRadioSwitchToOtherBuffer(void);
     void        bufferResetStreamPacketBuffer(void);
-    boolean     bufferSerialAddChar(char);
-    boolean     bufferSerialHasData(void);
-    void        bufferSerialReset(uint8_t);
-    boolean     bufferSerialTimeout(void);
-    void        bufferStreamAddChar(StreamPacketBuffer *, char);
     boolean     bufferStreamAddData(char *);
     void        bufferStreamFlush(StreamPacketBuffer *);
     void        bufferStreamFlushBuffers(void);
     boolean     bufferStreamReadyForNewPacket(StreamPacketBuffer *);
-    boolean     bufferStreamReadyToSendToHost(StreamPacketBuffer *buf);
     void        bufferStreamReset(void);
     void        bufferStreamReset(StreamPacketBuffer *);
-    boolean     bufferStreamSendToHost(StreamPacketBuffer *buf);
     void        bufferStreamStoreData(StreamPacketBuffer *, char *);
-    boolean     bufferStreamTimeout(void);
-    boolean     byteIdGetIsStream(uint8_t);
-    int         byteIdGetPacketNumber(uint8_t);
-    byte        byteIdGetStreamPacketType(uint8_t);
-    char        byteIdMake(boolean, uint8_t, char *, uint8_t);
-    byte        byteIdMakeStreamPacketType(uint8_t);
+    char        byteIdMake(boolean, int, volatile char *, int);
+    byte        byteIdMakeStreamPacketType(void);
     boolean     commsFailureTimeout(void);
     void        configure(uint8_t,uint32_t);
     void        configureDevice(void);
@@ -133,7 +127,8 @@ public:
     uint32_t    getPollTime(void);
     boolean     hasStreamPacket(void);
     boolean     hostPacketToSend(void);
-    boolean     isATailByte(uint8_t);
+    boolean     isAStreamPacketWaitingForLaunch(void);
+    boolean     isATailByteChar(char);
     void        ledFeedBackForPassThru(void);
     // void        moveStreamPacketToTempBuffer(volatile char *data);
     boolean     needToSetChannelNumber(void);
@@ -155,6 +150,7 @@ public:
     void        printPollTime(char);
     void        printSuccess(void);
     void        printValidatedCommsTimeout(void);
+    char        processSerialCharDevice(char);
     void        processCommsFailure(void);
     void        processCommsFailureSinglePacket(void);
     boolean     processDeviceRadioCharData(char *, int);
@@ -173,10 +169,14 @@ public:
     void        sendPollMessageToHost(void);
     void        sendRadioMessageToHost(byte);
     void        sendStreamPackets(void);
+    boolean     sendStreamPacketToTheHost(void);
+    void        sendTheDevicesFirstPacketToTheHost(void);
     boolean     serialWriteTimeOut(void);
     void        setByteIdForPacketBuffer(int);
     boolean     setChannelNumber(uint32_t);
     boolean     setPollTime(uint32_t);
+    boolean     storeCharToSerialBuffer(char);
+    boolean     thereIsDataInSerialBuffer(void);
     void        writeBufferToSerial(char *,int);
 
     //////////////////////
@@ -202,7 +202,6 @@ public:
     unsigned long timeOfLastMultipacketSendToHost;
 
     boolean channelNumberSaveAttempted;
-    boolean streamPacketsHaveHeads;
     volatile boolean isWaitingForNewChannelNumberConfirmation;
     volatile boolean isWaitingForNewPollTimeConfirmation;
     volatile boolean sendSerialAck;

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ A buffer to read into the ring buffer
 
 Adds a `,` to the main ring buffer. Used to ack that a time sync set command was sent.
 
+### bufferCleanSerial(numberOfPacketsToClean)
+
+Function to clean (clear/reset) the bufferSerial.
+
+**_numberOfPacketsToClean_** - `int`
+
+The number of packets you want to clean, for example, on init, we would clean all packets, but on cleaning from the RFduinoGZLL_onReceive() we would only clean the number of packets actually used.
+
 ### bufferRadioClean()
 
 Used to fill the buffer with all zeros. Should be used as frequently as possible. This is very useful if you need to ensure that no bad data is sent over the serial port.
@@ -99,93 +107,9 @@ Used to determine if there is data in the radio buffer. Most likely this data ne
 
 Used to reset the flags and positions of the radio buffer.
 
-### bufferSerialAddChar(newChar)
-
-Stores a char to the serial buffer. Used by both the Device and the Host. Protects the system from buffer overflow.
-
-**_newChar_** - {char}
-
-The new char to store to the serial buffer.
-
-**_Returns_** - {boolean}
-
-`true` if the new char was added to the serial buffer, `false` if not.
-
-### bufferSerialHasData()
-
-If there are packets to be sent in the serial buffer.
-
-**_Returns_** - {boolean}
-
-`true` if there are packets waiting to be sent from the serial buffer, `false` if not...
-
-### bufferSerialReset(n)
-
-Function to clean (clear/reset) the bufferSerial.
-
-**_n_** - `uint8_t`
-
-The number of packets you want to clean, for example, on init, we would clean all packets, but on cleaning from the RFduinoGZLL_onReceive() we would only clean the number of packets actually used.
-
-### bufferSerialTimeout()
-
-Based off the last time the serial port was read from, Determines if enough time has passed to qualify this data as a full serial page.
-
-**_Returns_** - {boolean}
-
-`true` if enough time has passed, `false` if not.
-
-### bufferStreamAddChar(buf, newChar)
-
-Process a char from the serial port on the Device. Enters the char into the stream state machine.
-
-**_buf_** - `StreamPacketBuffer *`
-
-The stream packet buffer to add the char to.
-
-**_newChar_** - `char`
-
-A new char to process.
-
-### bufferStreamReadyToSendToHost(buf)
-
-Utility function to return `true` if the the streamPacketBuffer is in the STREAM_STATE_READY. Normally used for determining if a stream packet is ready to be sent.
-
-**_buf_** - `StreamPacketBuffer *`
-
-The stream packet buffer to send to the Host.
-
-**_Returns_** - {boolean}
-
-`true` is the `buf` is in the ready state, `false` otherwise.
-
-### bufferStreamReset()
-
-Resets the first stream packet buffer to default settings.
-
-### bufferStreamReset(buf)
+### bufferResetStreamPacketBuffer()
 
 Resets the stream packet buffer to default settings
-
-**_buf_** - `StreamPacketBuffer *`
-
-Pointer to a stream packet buffer to reset.
-
-### bufferStreamSendToHost(buf)
-
-Sends the contents of the `buf` to the HOST, sends as stream packet with the proper byteId.
-
-**_buf_** - `StreamPacketBuffer *`
-
-Pointer to a stream packet buffer to be sent to the Host.
-
-### bufferStreamTimeout()
-
-Based off the last time the serial port was read from, Determines if enough time has passed to qualify this data as a stream packet.
-
-**_Returns_** - {boolean}
-
-`true` if enough time has passed, `false` if not.
 
 ### commsFailureTimeout()
 
@@ -234,6 +158,14 @@ Answers the question of if a packet is ready to be sent. need to check and there
 **_Returns_** {boolean}
 
 `true` if there is a packet ready to send on the Host
+
+### isAStreamPacketWaitingForLaunch()
+
+Checks to see if the stream packet parser is in the STREAM_STATE_READY which means that a stream packet is ready to be sent to the Host.
+
+**_Returns_** {boolean}
+
+`true` if there is a stream packet ready to send the Host
 
 ### ledFeedBackForPassThru()
 
@@ -342,6 +274,19 @@ The char to be read in.
 
 `true` if a packet should be sent from the serial buffer.            
 
+
+### processSerialCharDevice(newChar)
+
+Process a char from the serial port on the Device. Stores the char not only to the serial buffer but also tries enters the char into the stream state machine.
+
+**_newChar_** - {char}
+
+A new char to process
+
+**_Returns_** - {char}
+
+Passes `newChar` back out.
+
 ### resetPic32()
 
 Sends a soft reset command to the Pic 32 incase of an emergency.
@@ -366,10 +311,38 @@ The packet number sent.
 
 Sends a null byte to the host.
 
+### sendStreamPacketToTheHost()
+
+Sends the contents of the `streamPacketBuffer` to the HOST, sends as stream packet with the proper byteId.     
+
+**_Returns_** - {boolean}
+
+`true` when the packet has been added to the TX buffer.
+
 ### serialWriteTimeOut()
 
 Used to see if enough time has passed since the last serial read. Useful to if a serial transmission from the PC/Driver has concluded.   
 
 **_Returns_** - {boolean}
 
-`true` if enough time has passed.      
+`true` if enough time has passed.
+
+### storeCharToSerialBuffer(newChar)
+
+Stores a char to the serial buffer. Used by both the Device and the Host. Protects the system from buffer overflow.
+
+**_newChar_** - {char}
+
+The new char to store to the serial buffer.
+
+**_Returns_** - {boolean}
+
+`true` if the new char was added to the serial buffer,
+
+### thereIsDataInSerialBuffer()
+
+If there are packets to be sent in the serial buffer.
+
+**_Returns_** - {boolean}
+
+`true` if there are packets waiting to be sent from the serial buffer, `false` if not...       

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,3 @@
-# v2.0.0-rc.4 - Release Candidate 4
-
-### Breaking Changes
-
-* Removed function `isAStreamPacketWaitingForLaunch`. Now just check if stream packet buffer is in the ready state.
-* Renamed `thereIsDataInSerialBuffer` to `bufferSerialHasData`
-* Renamed `packetsInSerialBuffer` for `bufferSerialHasData` to follow new convention.
-* Renamed `sendStreamPacketToTheHost` to `bufferStreamSendToHost` to follow new convention.
-* Renamed `storeCharToSerialBuffer` to `bufferSerialAddChar` to follow new convention.
-* Refactored `processSerialCharDevice` into `bufferSerialAddChar` and `bufferStreamAddChar`.
-
 # v2.0.0-rc.3 - Release Candidate 3
 
 ### Enhancements

--- a/examples/RadioDevice32bit/RadioDevice32bit.ino
+++ b/examples/RadioDevice32bit/RadioDevice32bit.ino
@@ -29,10 +29,10 @@ void loop() {
     //  initiaite a communication between back to the Driver.
     if (radio.bufferSerial.overflowed) {
         // Clear the buffer holding all serial data.
-        radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+        radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
 
         // Clear the stream packet buffer
-        radio.bufferStreamReset(radio.streamPacketBuffer);
+        radio.bufferStreamReset();
 
         // Send reset message to the board
         radio.resetPic32();
@@ -47,31 +47,29 @@ void loop() {
         radio.bufferSerial.overflowed = false;
 
     } else {
-        while (Serial.available()) { // Is there new serial data available?
+        if (Serial.available()) { // Is there new serial data available?
             char newChar = Serial.read();
             // Mark the last serial as now;
             radio.lastTimeSerialRead = micros();
-            // Store it to serial buffer
-            radio.bufferSerialAddChar(newChar);
             // Get one char and process it
-            radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
+            radio.processSerialCharDevice(newChar);
             // Reset the poll timer to prevent contacting the host mid read
             radio.pollRefresh();
         }
 
-        if (radio.bufferStreamReadyToSendToHost(radio.streamPacketBuffer)) { // Is there a stream packet waiting to get sent to the Host?
+        if (radio.isAStreamPacketWaitingForLaunch()) { // Is there a stream packet waiting to get sent to the Host?
             // Has 80uS passed since the last time we read from the serial port?
-            if (radio.bufferStreamTimeout()) {
+            if (micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS)) {
                 if (radio.ackCounter < RFDUINOGZLL_MAX_PACKETS_ON_TX_BUFFER) {
-                    radio.bufferStreamSendToHost(radio.streamPacketBuffer);
+                    radio.sendStreamPacketToTheHost();
                 } else {
                     // packet loss incur... never seems to happen
                 }
             }
-        } else if (radio.bufferSerialHasData()) { // Is there data from the Pic waiting to get sent to Host
+        } else if (radio.thereIsDataInSerialBuffer()) { // Is there data from the Pic waiting to get sent to Host
             // Has 3ms passed since the last time the serial port was read. Only the
             //  first packet get's sent from here
-            if (radio.bufferSerialTimeout() && radio.bufferSerial.numberOfPacketsSent == 0 ) {
+            if ((micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_NRML_uS)) && radio.bufferSerial.numberOfPacketsSent == 0 ) {
                 // In order to do checksumming we must only send one packet at a time
                 //  this stands as the first time we are going to send a packet!
                 if (radio.ackCounter < RFDUINOGZLL_MAX_PACKETS_ON_TX_BUFFER) {
@@ -126,7 +124,7 @@ void RFduinoGZLL_onReceive(device_t device, int rssi, char *data, int len) {
         sendDataPacket = radio.packetToSend();
         if (sendDataPacket == false) {
             if (radio.bufferSerial.numberOfPacketsSent > 0) {
-                radio.bufferSerialReset(radio.bufferSerial.numberOfPacketsSent);
+                radio.bufferCleanSerial(radio.bufferSerial.numberOfPacketsSent);
             }
         }
     }

--- a/examples/RadioHost32bit/RadioHost32bit.ino
+++ b/examples/RadioHost32bit/RadioHost32bit.ino
@@ -48,7 +48,7 @@ void loop() {
         // Save the last time serial data was read to now
         radio.lastTimeSerialRead = micros();
         // Get data and put it on the serial buffer
-        boolean success = radio.bufferSerialAddChar(newChar);
+        boolean success = radio.storeCharToSerialBuffer(newChar);
         if (!success) {
             Serial.print("Failure: Input too large!$$$");
         }
@@ -160,7 +160,7 @@ void RFduinoGZLL_onReceive(device_t device, int rssi, char *data, int len) {
         sendDataPacket = radio.hostPacketToSend();
         if (sendDataPacket == false) {
             if (radio.bufferSerial.numberOfPacketsSent > 0) {
-                radio.bufferSerialReset(radio.bufferSerial.numberOfPacketsSent);
+                radio.bufferCleanSerial(radio.bufferSerial.numberOfPacketsSent);
             }
         }
     }

--- a/keywords.txt
+++ b/keywords.txt
@@ -15,28 +15,27 @@ ringBuffer      KEYWORD1
 #######################################
 begin                           KEYWORD2
 beginDebug                      KEYWORD2
+bufferAddStreamPacket           KEYWORD2
+bufferAddTimeSyncSentAck        KEYWORD2
+bufferCleanSerial               KEYWORD2
 bufferRadioClean                KEYWORD2
 bufferRadioFlushBuffers         KEYWORD2
+bufferRadioProcessSingle        KEYWORD2
 bufferRadioReset                KEYWORD2
-bufferSerialAddChar             KEYWORD2
-bufferSerialHasData             KEYWORD2
-bufferSerialReset               KEYWORD2
-bufferSerialTimeout             KEYWORD2
-bufferStreamAddChar             KEYWORD2
-bufferStreamReadyToSendToHost   KEYWORD2
-bufferStreamReset               KEYWORD2
-bufferStreamSendToHost          KEYWORD2
-bufferStreamTimeout             KEYWORD2
+bufferResetStreamPacketBuffer   KEYWORD2
 commsFailureTimeout             KEYWORD2
 didPCSendDataToHost             KEYWORD2
 flashNonVolatileMemory          KEYWORD2
 getChannelNumber                KEYWORD2
 getPollTime                     KEYWORD2
 hostPacketToSend                KEYWORD2
+isAStreamPacketWaitingForLaunch KEYWORD2
 ledFeedBackForPassThru          KEYWORD2
 packetToSend                    KEYWORD2
+packetsInSerialBuffer           KEYWORD2
 pollRefresh                     KEYWORD2
 printMessageToDriver            KEYWORD2
+processSerialCharDevice         KEYWORD2
 processCommsFailure             KEYWORD2
 processRadioCharDevice          KEYWORD2
 processRadioCharHost            KEYWORD2
@@ -46,7 +45,10 @@ resetPic32                      KEYWORD2
 sendPacketToDevice              KEYWORD2
 sendPacketToHost                KEYWORD2
 sendPollMessageToHost           KEYWORD2
+sendStreamPacketToTheHost       KEYWORD2
 serialWriteTimeOut              KEYWORD2
+storeCharToSerialBuffer         KEYWORD2
+thereIsDataInSerialBuffer       KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
+++ b/test/arduino/OpenBCI_Radio_Test/OpenBCI_Radio_Test.ino
@@ -56,7 +56,7 @@ void testByteIdMake() {
     byteId = radio.byteIdMake(false,9,NULL,0);
     test.assertEqualChar(byteId,(char)0x48,"Can set packet number of 9 in byteId");
 
-    radio.bufferSerialReset(12);
+    radio.bufferCleanSerial(12);
 
     for (int i = 0; i < OPENBCI_MAX_DATA_BYTES_IN_PACKET; i++) {
         radio.bufferSerial.packetBuffer->data[i] = 0;
@@ -937,13 +937,13 @@ void testBufferStreamReset() {
     radio.streamPacketBuffer->flushing = true;
     radio.streamPacketBuffer->bytesIn = 32;
     radio.streamPacketBuffer->typeByte = 2;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_READY;
+    radio.curStreamState = radio.STREAM_STATE_READY;
 
     radio.bufferStreamReset();
     test.assertBoolean(radio.streamPacketBuffer->flushing,false,"should set flushing to false",__LINE__);
     test.assertEqualInt(radio.streamPacketBuffer->bytesIn,0,"should set bytesIn to 0",__LINE__);
     test.assertEqualInt(radio.streamPacketBuffer->typeByte,0,"should set typeByte to 0",__LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should set stream state back to init",__LINE__);
+    test.assertEqualByte(radio.curStreamState, radio.STREAM_STATE_INIT, "should set stream state back to init",__LINE__);
 
     test.it("should be able to reset the second stream buffer");
     (radio.streamPacketBuffer + 1)->flushing = true;

--- a/test/arduino/Radio_Device_Tests/Radio_Device_Tests.ino
+++ b/test/arduino/Radio_Device_Tests/Radio_Device_Tests.ino
@@ -2,14 +2,10 @@
 #include "OpenBCI_Radios.h"
 #include "PTW-Arduino-Assert.h"
 
-int ledPin = 2;
-
 void setup() {
     // Get's serial up and running
-    pinMode(ledPin,OUTPUT);
     Serial.begin(115200);
     test.setSerial(Serial);
-    test.failVerbosity = true;
 }
 
 void loop() {
@@ -23,14 +19,11 @@ void loop() {
 void go() {
     // Start the test
     test.begin();
-    digitalWrite(ledPin, HIGH);
 
     testProcessChar();
-    testBufferStreamAddChar();
     testProcessRadioChar();
     testByteIdMakeStreamPacketType();
 
-    digitalWrite(ledPin, LOW);
     test.end();
 }
 
@@ -39,114 +32,8 @@ void go() {
 /*********    Process Char Tests    *********/
 /********************************************/
 /********************************************/
-
-void testBufferStreamAddChar() {
-    test.describe("bufferStreamAddChar");
-
-    testBufferStreamAddChar_STREAM_STATE_INIT();
-    testBufferStreamAddChar_STREAM_STATE_TAIL();
-    testBufferStreamAddChar_STREAM_STATE_STORING();
-    testBufferStreamAddChar_STREAM_STATE_READY();
-
-}
-
-void testBufferStreamAddChar_STREAM_STATE_INIT() {
-    test.detail("STREAM_STATE_INIT");
-    char newChar = (char)0x00;
-
-    test.it("should recognize the start byte and change state to storing");
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    newChar = (char)OPENBCI_STREAM_PACKET_HEAD;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should enter state storing", __LINE__);
-    test.assertEqualChar(radio.streamPacketBuffer->data[0],newChar,"should have stored the new char", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,1,"should have read one byte in",__LINE__);
-
-    test.it("should do nothing if not the start byte");
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    newChar = (char)0x00;
-    radio.streamPacketBuffer->data[0] = (char)0xF9; // newChar
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_INIT, "should stay in init state", __LINE__);
-    test.assertNotEqualChar(radio.streamPacketBuffer->data[0],newChar,"should not have stored the new char", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,0,"should not have read any bytes in",__LINE__);
-}
-
-void testBufferStreamAddChar_STREAM_STATE_TAIL() {
-    test.detail("STREAM_STATE_TAIL");
-
-    char newChar = 'A';
-
-    test.it("should set the typeByte and set state to ready");
-    newChar = (char)OPENBCI_STREAM_PACKET_TAIL;
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->typeByte, newChar, "should set the type byte to the stop byte", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_READY, "should be in the ready state", __LINE__);
-
-    test.it("should set state to init if byte is not stop byte or head byte");
-    newChar = (char)0x00;
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should be in the ready state", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn, 0, "should set bytesIn back to 0", __LINE__);
-
-    test.it("should set the state to storing if the byte is a head byte");
-    newChar = (char)OPENBCI_STREAM_PACKET_HEAD;
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->bytesIn = OPENBCI_MAX_PACKET_SIZE_BYTES;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_TAIL;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should enter state storing", __LINE__);
-    test.assertEqualChar(radio.streamPacketBuffer->data[0],newChar,"should have stored the new char", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,1,"should have read one byte in",__LINE__);
-
-}
-
-void testBufferStreamAddChar_STREAM_STATE_STORING() {
-    test.detail("STREAM_STATE_STORING");
-
-    char newChar = 'A';
-    uint8_t initialBytesIn = 5;
-
-    test.it("should store the new char to the buffer in position of bytesIn and increment byteIn by 1");
-    initialBytesIn = 5;
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->bytesIn = initialBytesIn;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_STORING;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_STORING, "should remain in state storing", __LINE__);
-    test.assertEqualChar(radio.streamPacketBuffer->data[initialBytesIn],newChar,"should have stored the new char to inital bytesIn position", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,initialBytesIn + 1,"should have incremented bytes in by 1",__LINE__);
-
-    test.it("should change state to tail if 32 bytes have been read in");
-    initialBytesIn = 31;
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->bytesIn = initialBytesIn;
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_STORING;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_TAIL, "should change state to tail", __LINE__);
-    test.assertEqualChar(radio.streamPacketBuffer->data[initialBytesIn],newChar,"should have stored the new char to inital bytesIn position", __LINE__);
-    test.assertEqualByte(radio.streamPacketBuffer->bytesIn,initialBytesIn + 1,"should have incremented bytes in by 32",__LINE__);
-
-}
-
-void testBufferStreamAddChar_STREAM_STATE_READY() {
-    test.detail("STREAM_STATE_READY");
-    test.it("should change to init state and set bytesIn to 0");
-    radio.bufferStreamReset(radio.streamPacketBuffer);
-    radio.streamPacketBuffer->state = radio.STREAM_STATE_READY;
-    radio.streamPacketBuffer->bytesIn = 32;
-    radio.bufferStreamAddChar(radio.streamPacketBuffer,(char)0x00);
-    test.assertEqualByte(radio.streamPacketBuffer->state, radio.STREAM_STATE_INIT, "should reset to init state",__LINE__);
-}
-
 void testProcessChar() {
-    testIsATailByte();
+    testIsATailByteChar();
     testProcessCharSingleChar();
     testProcessCharStreamPacket();
     testProcessCharStreamPackets();
@@ -154,15 +41,15 @@ void testProcessChar() {
     testProcessCharOverflow();
 }
 
-void testIsATailByte() {
-    test.describe("isATailByte");
+void testIsATailByteChar() {
+    test.describe("isATailByteChar");
 
-    test.assertBoolean(radio.isATailByte(0xC0),true,"Stream packet type 0",__LINE__);
-    test.assertBoolean(radio.isATailByte(0xC1),true,"Stream packet type 1",__LINE__);
-    test.assertBoolean(radio.isATailByte(0xC8),true,"Stream packet type 8",__LINE__);
-    test.assertBoolean(radio.isATailByte(0xCA),true,"Stream packet type 10",__LINE__);
-    test.assertBoolean(radio.isATailByte(0xCF),true,"Stream packet type 15",__LINE__);
-    test.assertBoolean(radio.isATailByte(0xB0),false,"Not a stream packet type",__LINE__);
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xC0),true,"Stream packet type 0");
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xC1),true,"Stream packet type 1");
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xC8),true,"Stream packet type 8");
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xCA),true,"Stream packet type 10");
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xCF),true,"Stream packet type 15");
+    test.assertEqualBoolean(radio.isATailByteChar((char)0xB0),false,"Not a stream packet type");
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -172,22 +59,19 @@ void testProcessCharSingleChar() {
     test.describe("processCharForSingleChar");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // try to add a char
     char input = 'A';
-    // Store it to serial buffer
-    radio.bufferSerialAddChar(input);
-    // Get one char and process it
-    radio.bufferStreamAddChar(radio.streamPacketBuffer,input);
+    radio.processChar(input);
 
     // Verify serial buffer
-    test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer",__LINE__);
-    test.assertEqualChar(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send",__LINE__);
-    test.assertEqualChar(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets",__LINE__);
+    test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer");
+    test.assertEqualChar(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send");
+    test.assertEqualChar(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets");
     // Verify stream packet buffer
-    test.assertEqualChar(radio.streamPacketBuffer->data[0],input,"Char stored to stream packet buffer",__LINE__);
+    test.assertEqualChar(radio.streamPacketBuffer.data[0],input,"Char stored to stream packet buffer");
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -196,11 +80,10 @@ void testProcessCharSingleChar() {
 
 void testProcessCharStreamPacket() {
     test.describe("processCharForStreamPacket");
-    test.it("should recognze a stream packet and wait 88us before allowing the stream packet to be sent with stop byte of 0xC0");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // Write a stream packet with end byte 0xA0
     writeAStreamPacketToProcessChar(0xC0);
@@ -208,23 +91,24 @@ void testProcessCharStreamPacket() {
     // Right away we want to see if enough time has passed, this should be false
     //  because we just processed a char, after this test is complete, we should
     //  be far passed 90uS
-    test.assertBoolean(radio.bufferStreamTimeout(),false,"waiting...",__LINE__);
+    boolean notEnoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
+    test.assertEqualBoolean(notEnoughTimePassed,false,"Type 0 waiting...");
 
     // Do we have a stream packet waiting to launch?
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_READY,"state ready with 0xC0",__LINE__);
+    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 0 loaded");
 
     // This should return true this time
-    test.assertBoolean(radio.bufferStreamTimeout(),true,"able to send",__LINE__);
+    boolean enoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
+    test.assertEqualBoolean(enoughTimePassed,true,"Type 0 ready");
 
     ///////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
     // Try a stream packet with another stop byte /////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
-    test.it("should recognze a stream packet and wait 88us before allowing the stream packet to be sent with stop byte of 0xC5");
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // Write a stream packet with end byte not 0xA0
     writeAStreamPacketToProcessChar(0xC5);
@@ -232,13 +116,15 @@ void testProcessCharStreamPacket() {
     // Right away we want to see if enough time has passed, this should be false
     //  because we just processed a char, after this test is complete, we should
     //  be far passed 90uS
-    test.assertBoolean(radio.bufferStreamTimeout(),false,"Type 5 waiting",__LINE__);
+    notEnoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
+    test.assertEqualBoolean(notEnoughTimePassed,false,"Type 5 waiting");
 
     // Do we have a stream packet waiting to launch?
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_READY,"state ready with 0xC5",__LINE__);
+    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true,"Type 5 loaded");
 
     // This should return true this time
-    test.assertBoolean(radio.bufferStreamTimeout(),true,"Type 5 ready",__LINE__);
+    enoughTimePassed = micros() > (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS);
+    test.assertEqualBoolean(enoughTimePassed,true,"Type 5 ready");
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -250,8 +136,8 @@ void testProcessCharStreamPackets() {
     test.describe("processCharForStreamPackets");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     int numberOfTrials = 9;
     char testMessage[] = "Sent 0";
@@ -260,15 +146,16 @@ void testProcessCharStreamPackets() {
     for (int i = 0; i < numberOfTrials; i++) {
         // Write a stream packet with end byte 0xC0
         writeAStreamPacketToProcessChar(0xC0);
-        radio.lastTimeSerialRead = micros();
         // Stream packet should be waiting
-        test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_READY,"state ready",__LINE__);
+        test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),true);
+        // Save the current time;
+        t1 = micros();
         // Wait
-        while(!radio.bufferStreamTimeout()) {};
+        while(micros() < (radio.lastTimeSerialRead + OPENBCI_TIMEOUT_PACKET_STREAM_uS)) {};
         // configure the test message
         testMessage[5] = (i + 1) + '0';
         // Send the stream packet
-        test.assertBoolean(radio.bufferStreamSendToHost(radio.streamPacketBuffer),true,testMessage);
+        test.assertEqualBoolean(radio.sendStreamPacketToTheHost(),true,testMessage);
     }
 }
 
@@ -277,8 +164,8 @@ void testProcessCharNotStreamPacket() {
     test.describe("processCharForNotStreamPacket");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // Write a stream packet
     writeAStreamPacketToProcessChar(0xC0);
@@ -287,17 +174,19 @@ void testProcessCharNotStreamPacket() {
     // Save current time as the last serial read
     radio.lastTimeSerialRead = micros();
     // Quick! Write another char
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, newChar);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_INIT,"state init",__LINE__);
-    test.assertEqualInt(radio.streamPacketBuffer->bytesIn,0,"0 bytes in",__LINE__);
+    radio.processChar(newChar);
+
+    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Too many packets in");
+    test.assertEqualInt(radio.streamPacketBuffer.bytesIn,0,"0 bytes in");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // Write a stream packet with a bad end byte
     writeAStreamPacketToProcessChar(0xB5);
-    test.assertEqualByte(radio.streamPacketBuffer->state,radio.STREAM_STATE_INIT,"bad end byte state init",__LINE__);
+    test.assertEqualBoolean(radio.isAStreamPacketWaitingForLaunch(),false,"Bad end byte");
+
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -308,27 +197,27 @@ void testProcessCharOverflow() {
     test.describe("testProcessCharOverflow");
 
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 
     // Write the max number of bytes in buffers
     int maxBytes = OPENBCI_MAX_NUMBER_OF_BUFFERS * OPENBCI_MAX_DATA_BYTES_IN_PACKET;
     // Write max bytes but stop 1 before
     for (int i = 0; i < maxBytes; i++) {
-        radio.bufferSerialAddChar(0x00);
+        radio.processChar(0x00);
     }
 
     // Verify that the emergency stop flag has NOT been deployed
-    test.assertBoolean(radio.bufferSerial.overflowed,false,"Overflow emergency not hit",__LINE__);
+    test.assertEqualBoolean(radio.bufferSerial.overflowed,false,"Overflow emergency not hit");
     // Verify that there are 15 buffers filled
-    test.assertEqualByte(radio.bufferSerial.numberOfPacketsToSend,OPENBCI_MAX_NUMBER_OF_BUFFERS,"15 buffers",__LINE__);
+    test.assertEqualInt(radio.bufferSerial.numberOfPacketsToSend,OPENBCI_MAX_NUMBER_OF_BUFFERS,"15 buffers");
     // Verify the write position
-    test.assertEqualByte((radio.bufferSerial.packetBuffer + OPENBCI_MAX_NUMBER_OF_BUFFERS - 1)->positionWrite,OPENBCI_MAX_PACKET_SIZE_BYTES,"32 bytes in buffer",__LINE__);
+    test.assertEqualInt((radio.bufferSerial.packetBuffer + OPENBCI_MAX_NUMBER_OF_BUFFERS - 1)->positionWrite,OPENBCI_MAX_PACKET_SIZE_BYTES,"32 bytes in buffer");
 
     // Write one more byte to overflow the buffer
-    radio.bufferSerialAddChar(0x00);
+    radio.processChar(0x00);
     // Verify that the emergency stop flag has been deployed
-    test.assertBoolean(radio.bufferSerial.overflowed,true,"Overflow emergency",__LINE__);
+    test.assertEqualBoolean(radio.bufferSerial.overflowed,true,"Overflow emergency");
 
     // Remember to clean up after yourself
     testProcessChar_CleanUp();
@@ -336,8 +225,8 @@ void testProcessCharOverflow() {
 
 void testProcessChar_CleanUp() {
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
 }
 
 /********************************************/
@@ -353,66 +242,57 @@ void testProcessRadioChar() {
 void testPacketToSend() {
     test.describe("testPacketToSend");
     // Clear the buffers
-    radio.bufferSerialReset(OPENBCI_MAX_NUMBER_OF_BUFFERS);
-    radio.bufferStreamReset(radio.streamPacketBuffer);
+    radio.bufferCleanSerial(OPENBCI_MAX_NUMBER_OF_BUFFERS);
+    radio.bufferResetStreamPacketBuffer();
     // Set the buffers up to think there is a packet to be sent
     //  by triggering a serial read
     char input = 'A';
     // Set last serial read to now
     radio.lastTimeSerialRead = micros();
     // Process that char!
-    radio.bufferSerialAddChar(input);
+    radio.processChar(input);
+    // Serial.print("Pos write: "); Serial.println(radio.bufferSerial.packetBuffer->positionWrite);
+    // test.assertEqualChar(radio.bufferSerial.packetBuffer->data[radio.bufferSerial.packetBuffer->positionWrite - 1],input,"Char stored to serial buffer");
+    // test.assertEqualInt(radio.bufferSerial.numberOfPacketsToSend,1,"Serial buffer has 1 packet to send");
+    // test.assertEqualInt(radio.bufferSerial.numberOfPacketsSent,0,"Serial buffer not sent any packets");
+
     // Less than 3ms has passed, veryify we can't send a packet
-    test.assertBoolean(radio.packetToSend(),false,"Can't send packet yet",__LINE__);
+    test.assertEqualBoolean(radio.packetToSend(),false,"Can't send packet yet");
+    // Serial.print("Packets sent: "); Serial.println(radio.bufferSerial.numberOfPacketsSent);
+    // Serial.print("Packets to send: "); Serial.println(radio.bufferSerial.numberOfPacketsToSend);
     // Wait for 3 ms
     delayMicroseconds(3000);
+    // Serial.print("Packets sent: "); Serial.println(radio.bufferSerial.numberOfPacketsSent);
+    // Serial.print("Packets to send: "); Serial.println(radio.bufferSerial.numberOfPacketsToSend);
     // Re ask if there is something to send
-    test.assertBoolean(radio.packetToSend(),true,"Enough time passed",__LINE__);
+    test.assertEqualBoolean(radio.packetToSend(),true,"Enough time passed");
 
 }
 
 void testByteIdMakeStreamPacketType() {
     test.describe("byteIdMakeStreamPacketType");
 
-    test.assertEqualChar(radio.byteIdMakeStreamPacketType(0xC5),5,"Can get type 5",__LINE__);
+    radio.streamPacketBuffer.typeByte = 0xC5;
+    test.assertEqualChar(radio.byteIdMakeStreamPacketType(),5,"Can get type 5");
 
     testProcessChar_CleanUp();
 }
 
 void writeAStreamPacketToProcessChar(char endByte) {
     // Quickly write a bunch of bytes into the buffers
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, 0x41); // make the first one a stream one so 0x41
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, 0x00); // Sample number what have you
-
-    for (byte i = 0; i < 8; i++) {
-        bufferStreamAdd3Byte(i);
-    }
-    // 5 bytes - channel 1
-    // 8 bytes - channel 2
-    // 11 bytes - channel 3
-    // 14 bytes - channel 4
-    // 17 bytes - channel 5
-    // 20 bytes - channel 6
-    // 23 bytes - channel 7
-    // 26 bytes - channel 8
-
-    for (byte i = 0; i < 3; i++) {
-        bufferStreamAdd2Byte(i);
-    }
-    // 28 bytes - Aux 1
-    // 30 bytes - Aux 2
-    // 32 bytes - Aux 3
-
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, endByte); // This locks in the final stream packet
+    radio.processChar(0x41); // make the first one a stream one so 0x41
+    radio.processChar(0x00); // Sample number what have you
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x01); // 5 bytes - channel 1
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x02); // 8 bytes - channel 2
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x03); // 11 bytes - channel 3
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x04); // 14 bytes - channel 4
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x05); // 17 bytes - channel 5
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x06); // 20 bytes - channel 6
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x07); // 23 bytes - channel 7
+    radio.processChar(0x00); radio.processChar(0x00); radio.processChar(0x08); // 26 bytes - channel 8
+    radio.processChar(0x00); radio.processChar(0x01); // 28 bytes - Aux 1
+    radio.processChar(0x00); radio.processChar(0x02); // 30 bytes - Aux 2
+    radio.processChar(0x00); radio.processChar(0x03); // 32 bytes - Aux 3
+    radio.processChar(endByte); // This locks in the final stream packet
     radio.lastTimeSerialRead = micros();
-}
-
-void bufferStreamAdd3Byte(byte n) {
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)n);
-}
-void bufferStreamAdd2Byte(byte n) {
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)0x00);
-    radio.bufferStreamAddChar(radio.streamPacketBuffer, (char)n);
 }

--- a/test/arduino/Radio_Host_Tests/Radio_Host_Tests.ino
+++ b/test/arduino/Radio_Host_Tests/Radio_Host_Tests.ino
@@ -135,7 +135,7 @@ void testProcessOutboundBufferCharDouble_OPENBCI_HOST_CMD_BAUD_FAST() {
 }
 
 void testProcessOutboundBufferCharDouble_OPENBCI_HOST_CMD_SYS_UP() {
-    radio.bufferSerialReset(1);
+    radio.bufferCleanSerial(1);
 
     test.it("should return to print the system status success message if the system is up");
     radio.systemUp = true;


### PR DESCRIPTION
### Enhancements
- Refactor of the was the device reads and processes chars. Completely auto tested.
- Complete auto test coverage over mission critical buffer functions.
- Less packet loss over same distance as compared with previous release candidates.
- Renamed a ton of functions to follow a new convention where there are three main buffer categories:
  - `Serial` which handles non streaming data coming from serial port to radio
  - `Radio` which handles non streaming data coming from radio to serial port
  - `Stream` which handles both streaming data in both directions.
### Breaking Changes
- Removed function `isAStreamPacketWaitingForLaunch`. Now just check if stream packet buffer is in the ready state.
- Renamed `thereIsDataInSerialBuffer` to `bufferSerialHasData`
- Renamed `packetsInSerialBuffer` for `bufferSerialHasData` to follow new convention.
- Renamed `sendStreamPacketToTheHost` to `bufferStreamSendToHost` to follow new convention.
- Renamed `storeCharToSerialBuffer` to `bufferSerialAddChar` to follow new convention.
- Refactored `processSerialCharDevice` into `bufferSerialAddChar` and `bufferStreamAddChar`.
- Removed ring buffer.
